### PR TITLE
Fix the duplicate uploading error

### DIFF
--- a/podonos/core/evaluator.py
+++ b/podonos/core/evaluator.py
@@ -105,10 +105,6 @@ class Evaluator:
             audio1 = self._set_audio(path1, tag1, self._eval_config)
             self._eval_audios.append([audio0, audio1])
 
-        # Upload files
-        # TODO: add lazy & background upload
-        self.upload_files()
-
     def upload_files(self) -> None:
         """Uploads the files for evaluation.
         This function holds until the file uploading finishes.
@@ -143,7 +139,11 @@ class Evaluator:
         """
         if not self._initialized or self._eval_config is None:
             raise ValueError("No evaluation session is open.")
-        
+
+        # Upload files
+        # TODO: add lazy & background upload
+        self.upload_files()
+
         # Create a json.
         session_json = self._eval_config.to_dict()
         session_json['files'] = self._eval_audio_json
@@ -168,7 +168,7 @@ class Evaluator:
         # Initialize variables.
         self._init_eval_variables()
         return {'status': 'ok'}
-    
+
     def _upload_one_file(self, remote_object_name: str, path: str) -> Tuple[str, str]:
         """
         Upload one file to server.


### PR DESCRIPTION
### 🚀 Pull Request Checklist

- [ ] Summarize the changes made in this pull request.
- [ ] Tested the changes to ensure they work as expected.
- [ ] Updated relevant documentation for the code changes.

### 📎 Related Issues

This may be a cause of SDK crash that customers experience.

### 📋 Description

Previous:
* Upload all the previous files when we add one file.
* Upload three files, actually we upload 6 files. If a customer uploads 10 files, we actually upload 45 files.
* If they delete one file at any time, it crashes.

### 📸 Screenshots (Optional)

<img width="203" alt="Screenshot 2024-06-12 at 5 38 45 PM" src="https://github.com/podonos/pysdk/assets/161088334/8766422e-5545-4f08-9474-b2fc06b9d104">

<img width="205" alt="Screenshot 2024-06-12 at 5 37 59 PM" src="https://github.com/podonos/pysdk/assets/161088334/a541fe4a-c7fd-4fd4-8776-183a539652a9">

### 📝 Additional Information

Needs to upgrade the SDK.
