### PR TITLE
[Fix] Add SPEECH_ into EvalType only when requesting API

### DIFF
--- a/podonos/common/enum.py
+++ b/podonos/common/enum.py
@@ -12,10 +12,13 @@ class TerminalColor(Enum):
     WARN = '\033[93m'
 
 class EvalType(Enum):
-    NMOS = 'SPEECH_NMOS'
-    QMOS = "SPEECH_QMOS"
-    P808 = 'SPEECH_P808'
-    SMOS = 'SPEECH_SMOS'
+    NMOS = 'NMOS'
+    QMOS = "QMOS"
+    P808 = 'P808'
+    SMOS = 'SMOS'
+    
+    def get_type(self) -> str:
+        return f"SPEECH_{self.value}"
 
 class Language(Enum):
     EN_US = 'en-us'

--- a/podonos/core/client.py
+++ b/podonos/core/client.py
@@ -52,10 +52,6 @@ class Client:
         if not self._initialized:
             raise ValueError("This function is called before initialization.")
 
-        # TODO: fix this clearly
-        if "SPEECH_" not in type:
-            type = "SPEECH_" + type
-
         return Evaluator(
             api_client=self._api_client,
             eval_config=EvalConfig(

--- a/podonos/core/config.py
+++ b/podonos/core/config.py
@@ -163,5 +163,5 @@ class EvalConfig:
             "description": self._eval_description,
             "language": self._eval_language.value,
             "granularity": self._eval_granularity,
-            "evaluation_type": self._eval_type.value
+            "evaluation_type": self._eval_type.get_type()
         }

--- a/podonos/core/evaluator.py
+++ b/podonos/core/evaluator.py
@@ -258,7 +258,7 @@ class Evaluator:
         try:
             response = self._api_client.post("request-evaluation", {
                 'eval_id': self._eval_config.eval_id,
-                'eval_type': self._eval_config.eval_type.value
+                'eval_type': self._eval_config.eval_type.get_type()
             })
             response.raise_for_status()
         except requests.exceptions.HTTPError as e:


### PR DESCRIPTION
### 🚀 Pull Request Checklist

- [x] Summarize the changes made in this pull request.
- [x] Tested the changes to ensure they work as expected.

### 📎 Related Issues

close #48 

### 📋 Description

Add "SPEECH_" into eval type when only requesting evaluation API

### 📸 Screenshots (Optional)

<img width="1235" alt="스크린샷 2024-06-25 오후 5 45 05" src="https://github.com/podonos/pysdk/assets/165979360/6c18e3ec-9e12-43e3-8248-1c7fe4ad4282">