### PR TITLE
[Fix] Set frames as zero if the soundfile's error occurs

### DIFF
--- a/podonos/core/audio.py
+++ b/podonos/core/audio.py
@@ -57,8 +57,8 @@ class AudioMeta:
         suffix = Path(path).suffix
         support_file_type = [".wav", ".mp3", ".flac"]
         assert suffix in support_file_type, f"Unsupported file format: {path}. It must be wav, mp3, or flac."
-        # if suffix in support_file_type:
-        #     return self._get_audio_info(path)
+        if suffix in support_file_type:
+            return self._get_audio_info(path)
         return 0, 0, 0
 
     def _get_audio_info(self, filepath: str) -> Tuple[int, int, int]:

--- a/podonos/core/audio.py
+++ b/podonos/core/audio.py
@@ -6,8 +6,8 @@ from pathlib import Path
 from typing import Tuple, Optional, Dict, Any, List
 
 from podonos.common.enum import QuestionFileType
-from podonos.core.base import *
 from podonos.common.util import generate_random_name, process_paths_to_posix
+from podonos.core.base import *
 from podonos.core.file import File
 
 
@@ -56,7 +56,7 @@ class AudioMeta:
         # Check if this is wav or mp3.
         suffix = Path(path).suffix
         support_file_type = [".wav", ".mp3", ".flac"]
-        assert suffix in support_file_type, f"Unsupported file format: {path}. It must be wav or mp3."
+        assert suffix in support_file_type, f"Unsupported file format: {path}. It must be wav, mp3, or flac."
         if suffix in support_file_type:
             return self._get_audio_info(path)
         return 0, 0, 0
@@ -73,20 +73,27 @@ class AudioMeta:
             FileNotFoundError: if the file is not found.
             wave.Error: if the file doesn't read properly.
         """
-        log.check_notnone(filepath)
-        log.check_ne(filepath, "")
+        try:
+            log.check_notnone(filepath)
+            log.check_ne(filepath, "")
 
-        f = sf.SoundFile(filepath)
-        nframes = f.frames
-        nchannels = f.channels
-        framerate = f.samplerate
-        log.check_gt(nframes, 0)
-        log.check_gt(nchannels, 0)
-        log.check_gt(framerate, 0)
+            f = sf.SoundFile(filepath)
+            nframes = f.frames
+            nchannels = f.channels
+            framerate = f.samplerate
+            log.check_gt(nframes, 0)
+            log.check_gt(nchannels, 0)
+            log.check_gt(framerate, 0)
 
-        duration_in_ms = int(nframes * 1000.0 / float(framerate))
-        log.check_gt(duration_in_ms, 0)
-        return nchannels, framerate, duration_in_ms
+            duration_in_ms = int(nframes * 1000.0 / float(framerate))
+            log.check_gt(duration_in_ms, 0)
+            return nchannels, framerate, duration_in_ms
+        except AttributeError as e:
+            log.error(f"Attribute error while getting audio info: {e}")
+            return 0, 0, 0
+        except Exception as e:
+            log.error(f"Error getting audio info: {e}")
+            return 0, 0, 0
 
 
 class Audio(File):

--- a/podonos/core/audio.py
+++ b/podonos/core/audio.py
@@ -19,9 +19,9 @@ class AudioMeta:
     def __init__(self, path: str) -> None:
         log.check_notnone(path)
         self._nchannels, self._framerate, self._duration_in_ms = self._set_audio_meta(path)
-        log.check_gt(self._nchannels, 0)
-        log.check_gt(self._framerate, 0)
-        log.check_gt(self._duration_in_ms, 0)
+        log.check_ge(self._nchannels, 0)
+        log.check_ge(self._framerate, 0)
+        log.check_ge(self._duration_in_ms, 0)
 
     @property
     def nchannels(self) -> int:
@@ -57,8 +57,8 @@ class AudioMeta:
         suffix = Path(path).suffix
         support_file_type = [".wav", ".mp3", ".flac"]
         assert suffix in support_file_type, f"Unsupported file format: {path}. It must be wav, mp3, or flac."
-        if suffix in support_file_type:
-            return self._get_audio_info(path)
+        # if suffix in support_file_type:
+        #     return self._get_audio_info(path)
         return 0, 0, 0
 
     def _get_audio_info(self, filepath: str) -> Tuple[int, int, int]:


### PR DESCRIPTION
### 🚀 Pull Request Checklist

- [x] Summarize the changes made in this pull request.
- [x] Tested the changes to ensure they work as expected.
- [x] Updated relevant documentation for the code changes.

### 📎 Related Issues

close #181 

### 📋 Description

AttributeError: 'SoundFile' object has no attribute 'frames' error may occur if some voice files do not read meta information in the header or the customer uses an older version of the soundfile.

Even if an error occurs, it will not be a big problem in conducting the evaluation because it is going through the process of verifying once again on the server after uploading.