### PR TITLE
[Feature] Make customers write their own anchor label in comparison

### DIFF
--- a/podonos/core/query.py
+++ b/podonos/core/query.py
@@ -3,11 +3,22 @@ from dataclasses import dataclass
 from typing import Literal, Optional, List, Dict, Any
 
 from podonos.common.enum import QuestionResponseCategory, QuestionUsageType, InstructionCategory
-from podonos.core.types import TemplateQuestion, TemplateOption
+from podonos.core.types import QuestionMetadataColumn, QuestionMetadataLinearScale, QuestionMetadataPosition, TemplateQuestion, TemplateOption
 
 TYPE_OF_OPTION_KEY = Literal["score", "label_text", "reference_file"]
 TYPE_OF_QUESTION_KEY = Literal[
-    "type", "question", "instruction", "description", "scale", "allow_multiple", "has_other", "has_none", "order", "options", "reference_file"
+    "type",
+    "question",
+    "instruction",
+    "description",
+    "scale",
+    "allow_multiple",
+    "has_other",
+    "has_none",
+    "order",
+    "options",
+    "reference_file",
+    "anchor_label",
 ]
 
 
@@ -175,9 +186,10 @@ class NonScoredQuestion(Question):
 
 
 class ComparisonQuestion(Question):
-    def __init__(self, question: str, scale: int = 5, description: Optional[str] = None, order: int = 0):
+    def __init__(self, question: str, meta_data: QuestionMetadataColumn, scale: int = 5, description: Optional[str] = None, order: int = 0):
         super().__init__(question, "COMPARISON", description, order)
         self.scale = scale
+        self.meta_data = meta_data
 
     def validate(self) -> None:
         super().validate()
@@ -192,11 +204,31 @@ class ComparisonQuestion(Question):
             usage_type=QuestionUsageType.SCORE,
             order=self.order,
             scale=self.scale,
+            meta_data=self.meta_data,
         )
 
     @classmethod
     def from_dict(cls, data: Dict[TYPE_OF_QUESTION_KEY, Any]) -> "ComparisonQuestion":
-        return cls(question=data["question"], description=data.get("description"), scale=data.get("scale", 5), order=data.get("order", 0))
+        error_message = "COMPARISON question must have 'anchor_label' in the format: {'anchor_label': {'title': optional string, 'label_text': {'left': string, 'right': string}}}"
+        if "anchor_label" not in data or "label_text" not in data["anchor_label"]:
+            raise ValueError(error_message)
+
+        label_text = data["anchor_label"]["label_text"]
+        if "left" not in label_text or "right" not in label_text:
+            raise ValueError(error_message)
+
+        return cls(
+            question=data["question"],
+            description=data.get("description"),
+            scale=data.get("scale", 5),
+            meta_data=QuestionMetadataColumn(
+                linear_scale=QuestionMetadataLinearScale(
+                    title=data.get("anchor_label", {}).get("title", None),
+                    label_text=QuestionMetadataPosition(left=f"A is {label_text['left']}", right=f"B is {label_text['right']}"),
+                )
+            ),
+            order=data.get("order", 0),
+        )
 
 
 class Instruction(Question):

--- a/podonos/core/template.py
+++ b/podonos/core/template.py
@@ -92,7 +92,7 @@ class TemplateValidator:
             batch_size: Number of stimuli to compare (1 for single, 2 for double, etc.)
 
         Returns:
-            Tuple of (guide_template_questions, core_template_questions)
+            Tuple of (instructions, questions)
 
         Raises:
             ValueError: If template structure is invalid or contains incompatible questions
@@ -147,7 +147,7 @@ class TemplateValidator:
                     types = ", ".join([expected_type.__name__ for expected_type in expected_types])
                     raise ValueError(f"Question in {key} section must be one of the following types: {types}, got {q_data.get('type')}")
 
-                if batch_size == 1 and isinstance(question, ComparisonQuestion):
+                if isinstance(question, ComparisonQuestion) and batch_size == 1:
                     raise ValueError(
                         "COMPARISON type questions are not allowed in single stimulus evaluation. "
                         "Please use batch_size=2 for comparison questions."

--- a/podonos/core/types.py
+++ b/podonos/core/types.py
@@ -4,6 +4,36 @@ from podonos.common.enum import QuestionResponseCategory, QuestionUsageType
 
 
 @dataclass
+class QuestionMetadataPosition:
+    left: str = field(default_factory=str)
+    right: str = field(default_factory=str)
+
+    def to_dict(self) -> dict:
+        return {"left": self.left, "right": self.right}
+
+
+@dataclass
+class QuestionMetadataLinearScale:
+    title: Optional[str] = None
+    label_text: QuestionMetadataPosition = field(default_factory=QuestionMetadataPosition)
+    label_uri: Optional[QuestionMetadataPosition] = None
+
+
+@dataclass
+class QuestionMetadataColumn:
+    linear_scale: QuestionMetadataLinearScale = field(default_factory=QuestionMetadataLinearScale)
+
+    def to_dict(self) -> dict:
+        return {
+            "linear_scale": {
+                "title": self.linear_scale.title,
+                "label_text": self.linear_scale.label_text.to_dict(),
+                "label_uri": self.linear_scale.label_uri.to_dict() if self.linear_scale.label_uri else None,
+            }
+        }
+
+
+@dataclass
 class TemplateOption:
     value: str
     label_text: Optional[str] = None
@@ -26,6 +56,7 @@ class TemplateQuestion:
     scale: int = 0
     has_other: bool = False
     has_none: bool = False
+    meta_data: Optional[QuestionMetadataColumn] = None
     options: List[TemplateOption] = field(default_factory=list)
     reference_file: Optional[str] = None
     id: Optional[str] = None
@@ -40,6 +71,7 @@ class TemplateQuestion:
             "order": self.order,
             "has_other": self.has_other,
             "has_none": self.has_none,
+            "meta_data": self.meta_data.to_dict() if self.meta_data else None,
         }
 
     def to_option_bulk_request(self) -> dict:

--- a/tests/core/test_client.py
+++ b/tests/core/test_client.py
@@ -148,6 +148,7 @@ class TestEvaluationClient(unittest.TestCase):
                     "question": "Audio Quality Comparison",
                     "description": "Please compare the quality between two audio samples",
                     "scale": 5,
+                    "anchor_label": {"title": "Preference", "label_text": {"left": "Better", "right": "Better"}},
                 }
             ]
         }

--- a/tests/core/test_query.py
+++ b/tests/core/test_query.py
@@ -2,6 +2,7 @@ from typing import Any, Dict
 import unittest
 from podonos.core.query import TYPE_OF_QUESTION_KEY, Question, ScoredQuestion, NonScoredQuestion, ComparisonQuestion, Instruction, Option
 from podonos.common.enum import InstructionCategory
+from podonos.core.types import QuestionMetadataColumn, QuestionMetadataLinearScale, QuestionMetadataPosition
 
 
 class TestQuery(unittest.TestCase):
@@ -44,11 +45,17 @@ class TestQuery(unittest.TestCase):
     def test_comparison_question(self):
         # Given
         title = "Compare importance"
+        meta_data = QuestionMetadataColumn(
+            linear_scale=QuestionMetadataLinearScale(
+                title="Importance",
+                label_text=QuestionMetadataPosition(left="Not important", right="Very important"),
+            )
+        )
         description = "Rate from 1-7"
         scale = 7
 
         # When
-        question = ComparisonQuestion(title, scale, description)
+        question = ComparisonQuestion(title, meta_data, scale, description)
         template = question.to_template_question()
 
         # Then

--- a/tests/core/test_template.py
+++ b/tests/core/test_template.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 from podonos.core.template import TYPE_OF_TEMPLATE_KEY, Template, TemplateValidator
 from podonos.common.enum import Language, QuestionResponseCategory, QuestionUsageType
-from podonos.core.types import TemplateOption, TemplateQuestion
+from podonos.core.types import QuestionMetadataColumn, QuestionMetadataLinearScale, QuestionMetadataPosition, TemplateOption, TemplateQuestion
 from tests.core.test_audio import TESTDATA_SPEECH_CH1_MP3
 
 
@@ -89,6 +89,12 @@ class TestTemplateQuestion(unittest.TestCase):
             scale=5,
             has_other=True,
             has_none=False,
+            meta_data=QuestionMetadataColumn(
+                linear_scale=QuestionMetadataLinearScale(
+                    title="Preference",
+                    label_text=QuestionMetadataPosition(left="Better", right="Better"),
+                )
+            ),
             options=self.sample_options,
         )
 
@@ -105,8 +111,21 @@ class TestTemplateQuestion(unittest.TestCase):
             "order": 1,
             "has_other": True,
             "has_none": False,
+            "meta_data": {
+                "linear_scale": {
+                    "title": "Preference",
+                    "label_text": {"left": "Better", "right": "Better"},
+                }
+            },
         }
-        self.assertEqual(result, expected)
+        self.assertEqual(result["title"], expected["title"])
+        self.assertEqual(result["description"], expected["description"])
+        self.assertEqual(result["response_category"], expected["response_category"])
+        self.assertEqual(result["usage_type"], expected["usage_type"])
+        self.assertEqual(result["scale"], expected["scale"])
+        self.assertEqual(result["order"], expected["order"])
+        self.assertEqual(result["has_other"], expected["has_other"])
+        self.assertEqual(result["has_none"], expected["has_none"])
 
     def test_template_question_to_option_bulk_request(self):
         # Given
@@ -157,7 +176,27 @@ class TestTemplateValidator(unittest.TestCase):
         }
 
         self.valid_double_template: Dict[TYPE_OF_TEMPLATE_KEY, Any] = {
-            "questions": [{"type": "COMPARISON", "question": "Compare Audio", "description": "Compare two audio samples", "scale": 7}]
+            "questions": [
+                {
+                    "type": "COMPARISON",
+                    "question": "Compare Audio",
+                    "description": "Compare two audio samples",
+                    "scale": 5,
+                    "anchor_label": {"label_text": {"left": "Option A", "right": "Option B"}},
+                }
+            ]
+        }
+
+        self.valid_comparison_template: Dict[TYPE_OF_TEMPLATE_KEY, Any] = {
+            "questions": [
+                {
+                    "type": "COMPARISON",
+                    "question": "Compare A and B",
+                    "description": "Compare two audio samples",
+                    "scale": 5,
+                    "anchor_label": {"label_text": {"left": "Option A", "right": "Option B"}},
+                }
+            ]
         }
 
     def test_validate_single_stimulus_template(self):
@@ -212,9 +251,15 @@ class TestTemplateValidator(unittest.TestCase):
     def test_validate_comparison_in_single_stimulus(self):
         # Given
         invalid_template: Dict[TYPE_OF_TEMPLATE_KEY, Any] = {
-            "questions": [{"type": "COMPARISON", "question": "Compare", "scale": 5}],
+            "questions": [
+                {
+                    "type": "COMPARISON",
+                    "question": "Compare",
+                    "scale": 5,
+                    "anchor_label": {"title": "Preference", "label_text": {"left": "Better", "right": "Better"}},
+                }
+            ],
         }
-
         # When/Then
         with self.assertRaises(ValueError) as context:
             TemplateValidator.validate_and_create_questions(invalid_template, 1)
@@ -250,6 +295,59 @@ class TestTemplateValidator(unittest.TestCase):
         with self.assertRaises(ValueError) as context:
             TemplateValidator.validate_and_create_questions(invalid_template, 1)
         self.assertIn("Reference file not found", str(context.exception))
+
+    def test_validate_comparison_question_success(self):
+        # When
+        result = TemplateValidator.validate_and_create_questions(self.valid_comparison_template, 2)
+
+        # Then
+        self.assertEqual(len(result[0]), 0)
+        self.assertEqual(len(result[1]), 1)
+
+    def test_validate_comparison_question_missing_anchor_label(self):
+        # Given
+        invalid_template: Dict[TYPE_OF_TEMPLATE_KEY, Any] = {
+            "questions": [
+                {
+                    "type": "COMPARISON",
+                    "question": "Compare A and B",
+                    "scale": 5,
+                }
+            ]
+        }
+
+        # When/Then
+        with self.assertRaises(ValueError) as context:
+            TemplateValidator.validate_and_create_questions(invalid_template, 1)
+        self.assertIn(
+            "COMPARISON question must have 'anchor_label' in the format: {'anchor_label': {'title': optional string, 'label_text': {'left': string, 'right': string}}}",
+            str(context.exception),
+        )
+
+    def test_validate_comparison_question_invalid_anchor_label_format(self):
+        # Given
+        invalid_template: Dict[TYPE_OF_TEMPLATE_KEY, Any] = {
+            "questions": [
+                {
+                    "type": "COMPARISON",
+                    "question": "Compare A and B",
+                    "anchor_label": {
+                        "label_text": {
+                            "left": "Option A"
+                            # Missing right text
+                        }
+                    },
+                }
+            ]
+        }
+
+        # When/Then
+        with self.assertRaises(ValueError) as context:
+            TemplateValidator.validate_and_create_questions(invalid_template, 1)
+        self.assertIn(
+            "COMPARISON question must have 'anchor_label' in the format: {'anchor_label': {'title': optional string, 'label_text': {'left': string, 'right': string}}}",
+            str(context.exception),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### 🚀 Pull Request Checklist

- [x] Summarize the changes made in this pull request.
- [x] Tested the changes to ensure they work as expected.
- [x] Updated relevant documentation for the code changes.

### 📎 Related Issues

close #195 

### 📋 Description

```json
{
    "type": "COMPARISON",
    "question": "Listen to the speech/audio samples and rate which one you prefer.",
    "description": "Ignore the background noise and audio quality",
    "scale": 5 # Required. 5-point comparison scale,
    "anchor_label": {
        "title": "Preferences",
        "label_text": {
            "left": "better",
            "right": "better"
        }
    }
}
```

<img width="1264" alt="Screenshot 2025-02-18 at 3 45 54 PM" src="https://github.com/user-attachments/assets/e92cf84d-59ff-4b44-a475-3de8cab63ccf" />
