### PR TITLE
[Feature] Add Singapore English

### DIFF
--- a/podonos/common/enum.py
+++ b/podonos/common/enum.py
@@ -154,6 +154,7 @@ class Language(Enum):
     ENGLISH_AUSTRALIAN = "en-au"
     ENGLISH_CANADIAN = "en-ca"
     ENGLISH_INDIA = "en-in"
+    ENGLISH_SINGAPOREAN = "en-sg"
     PORTUGUESE_PORTUGAL = "pt-pt"
     PORTUGUESE_BRAZIL = "pt-br"
     KOREAN = "ko-kr"

--- a/podonos/core/config.py
+++ b/podonos/core/config.py
@@ -1,10 +1,10 @@
 from datetime import datetime, timedelta
 from typing import Any, Dict, Optional
 
-from podonos.core.base import *
 from podonos.common.constant import PODONOS_CONTACT_EMAIL
 from podonos.common.enum import AIEvalType, EvalType, Language
 from podonos.common.validator import Rules, validate_args
+from podonos.core.base import *
 
 
 class EvalConfigDefault:
@@ -167,7 +167,7 @@ class EvalConfig:
             EvalType.RANKING.value,
         ]:
             raise ValueError(
-                f'"type" must be one of {{NMOS, QMOS, SMOS, P808, PREF, CUSTOM_SINGLE, CUSTOM_DOUBLE, RANKING}}. \n'
+                '"type" must be one of {NMOS, QMOS, SMOS, P808, PREF, CUSTOM_SINGLE, CUSTOM_DOUBLE, RANKING}. \n'
                 + f"Do you want other evaluation types? Let us know at {PODONOS_CONTACT_EMAIL}"
             )
         return EvalType(eval_type)
@@ -180,6 +180,7 @@ class EvalConfig:
             Language.ENGLISH_BRITISH.value,
             Language.ENGLISH_CANADIAN.value,
             Language.ENGLISH_INDIA.value,
+            Language.ENGLISH_SINGAPOREAN.value,
             Language.PORTUGUESE_PORTUGAL.value,
             Language.PORTUGUESE_BRAZIL.value,
             Language.KOREAN.value,
@@ -195,8 +196,8 @@ class EvalConfig:
             Language.AUDIO.value,
         ]:
             raise ValueError(
-                f'"lan" must be one of the supported language strings. '
-                + f"See https://www.podonos.com/docs/reference#create-evaluator \n"
+                '"lan" must be one of the supported language strings. '
+                + "See https://www.podonos.com/docs/reference#create-evaluator \n"
                 + f"Do you want us to support other languages? Let us know at {PODONOS_CONTACT_EMAIL}."
             )
         return Language(eval_language)
@@ -204,19 +205,19 @@ class EvalConfig:
     @validate_args(eval_ai_type=Rules.optional_instance_of(AIEvalType))
     def _validate_eval_ai_type(self, eval_ai_type: Optional[AIEvalType]) -> Optional[AIEvalType]:
         if eval_ai_type and eval_ai_type not in [AIEvalType.ALL]:
-            raise ValueError(f'"ai_type" must be one of {{ALL}}.')
+            raise ValueError('"ai_type" must be one of {ALL}.')
         return eval_ai_type
 
     @validate_args(num_eval=Rules.positive_not_none)
     def _validate_eval_num(self, num_eval: int) -> int:
         if num_eval < 1:
-            raise ValueError(f'"num_eval" must be >= 1.')
+            raise ValueError('"num_eval" must be >= 1.')
         return num_eval
 
     @validate_args(granularity=Rules.float_not_none)
     def _validate_eval_granularity(self, granularity: float) -> float:
         if granularity not in [0.5, 1.0]:
-            raise ValueError(f'"granularity" must be one of 0.5 and 1.0')
+            raise ValueError('"granularity" must be one of 0.5 and 1.0')
         return granularity
 
     @validate_args(eval_type=Rules.str_non_empty)
@@ -230,7 +231,7 @@ class EvalConfig:
         elif EvalType.is_triple(eval_type):
             return 3
         else:
-            raise ValueError(f'"eval_type" must be one of {{NMOS, QMOS, P808, RANKING, SMOS, PREF, CSMOS, CUSTOM_SINGLE, CUSTOM_DOUBLE}}.')
+            raise ValueError('"eval_type" must be one of {NMOS, QMOS, P808, RANKING, SMOS, PREF, CSMOS, CUSTOM_SINGLE, CUSTOM_DOUBLE}.')
 
     # TODO: allow floating point hours, e.g. 0.5.
     @validate_args(due_hours=Rules.positive_not_none)
@@ -255,7 +256,7 @@ class EvalConfig:
             EvalType.P808.value,
             EvalType.CUSTOM_SINGLE.value,
         ]:
-            raise ValueError(f'"eval_type" must be one of {{NMOS, QMOS, P808, CUSTOM_SINGLE}} when using "use_annotation"')
+            raise ValueError('"eval_type" must be one of {NMOS, QMOS, P808, CUSTOM_SINGLE} when using "use_annotation"')
         return eval_use_annotation
 
     def to_dict(self) -> Dict[str, Any]:

--- a/tests/common/test_enum.py
+++ b/tests/common/test_enum.py
@@ -1,5 +1,6 @@
 import unittest
-from podonos.common.enum import Language, EvalType, AIEvalType
+
+from podonos.common.enum import AIEvalType, EvalType, Language
 
 
 class TestLanguageEnum(unittest.TestCase):
@@ -12,6 +13,7 @@ class TestLanguageEnum(unittest.TestCase):
         self.assertEqual(Language.ENGLISH_AUSTRALIAN.value, "en-au")
         self.assertEqual(Language.ENGLISH_CANADIAN.value, "en-ca")
         self.assertEqual(Language.ENGLISH_INDIA.value, "en-in")
+        self.assertEqual(Language.ENGLISH_SINGAPOREAN.value, "en-sg")
         self.assertEqual(Language.PORTUGUESE_PORTUGAL.value, "pt-pt")
         self.assertEqual(Language.PORTUGUESE_BRAZIL.value, "pt-br")
         self.assertEqual(Language.KOREAN.value, "ko-kr")
@@ -41,6 +43,7 @@ class TestLanguageEnum(unittest.TestCase):
             ("en-au", Language.ENGLISH_AUSTRALIAN),
             ("en-ca", Language.ENGLISH_CANADIAN),
             ("en-in", Language.ENGLISH_INDIA),
+            ("en-sg", Language.ENGLISH_SINGAPOREAN),
         ]
 
         for value, expected_enum in english_variants:


### PR DESCRIPTION
### 🚀 Pull Request Checklist

- [x] Summarize the changes made in this pull request.
- [x] Tested the changes to ensure they work as expected.
- [x] Updated relevant documentation for the code changes.

### 📎 Related Issues

closes #267

### 📋 Description

This pull request adds support for Singaporean English as a language option and makes minor improvements to error messages and code formatting. The most important changes are grouped below:

**Language Support:**

* Added `ENGLISH_SINGAPOREAN` (`en-sg`) to the `Language` enum in `podonos/common/enum.py`, and updated validation logic in `podonos/core/config.py` to accept this new language. [[1]](diffhunk://#diff-a889aa0c05e8813de53f393019825110c8446f394c625a55b5a982be4089d37bR157) [[2]](diffhunk://#diff-b4f71256f433af14ff05004324f8d12a9a043533d489d1ea3f7503cdc771b2ceR183)

**Testing:**

* Updated unit tests in `tests/common/test_enum.py` to include checks for the new Singaporean English language value and its handling. [[1]](diffhunk://#diff-20f3afbddd1ce28fa17a255208951d41ee9077fea07fe25b89b3c8908772c880R16) [[2]](diffhunk://#diff-20f3afbddd1ce28fa17a255208951d41ee9077fea07fe25b89b3c8908772c880R46)

**Error Message and Import Improvements:**

* Standardized error messages in `podonos/core/config.py` by removing unnecessary `f`-strings and curly braces in user-facing strings. [[1]](diffhunk://#diff-b4f71256f433af14ff05004324f8d12a9a043533d489d1ea3f7503cdc771b2ceL170-R170) [[2]](diffhunk://#diff-b4f71256f433af14ff05004324f8d12a9a043533d489d1ea3f7503cdc771b2ceL198-R220) [[3]](diffhunk://#diff-b4f71256f433af14ff05004324f8d12a9a043533d489d1ea3f7503cdc771b2ceL233-R234) [[4]](diffhunk://#diff-b4f71256f433af14ff05004324f8d12a9a043533d489d1ea3f7503cdc771b2ceL258-R259)
* Fixed import order and formatting in `podonos/core/config.py` and `tests/common/test_enum.py` for consistency. [[1]](diffhunk://#diff-b4f71256f433af14ff05004324f8d12a9a043533d489d1ea3f7503cdc771b2ceL4-R7) [[2]](diffhunk://#diff-20f3afbddd1ce28fa17a255208951d41ee9077fea07fe25b89b3c8908772c880L2-R3)

