### PR TITLE
[Chore] Drop Python 3.8/3.9 support, add 3.13/3.14 support

### DIFF
--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/test-window.yml
+++ b/.github/workflows/test-window.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -3,11 +3,13 @@
 ## Quick Start
 
 ### 👨‍💻 1. Get an API key
+
 Visit [https://www.podonos.com](https://www.podonos.com), log in or sign up, and get an API key.
 For more details, see [Docs](https://www.podonos.com/docs/apikey)
 
 ### 💾 2. Install podonos Python package
-First of all, make sure you have installed Python 3.8 or newer
+
+First of all, make sure you have installed Python 3.10 or newer
 
 ```bash
 python --version
@@ -20,6 +22,7 @@ pip install podonos
 ```
 
 ### 🎙️ 3. Start speech evaluation
+
 ```python
 import podonos
 from podonos import *
@@ -32,11 +35,13 @@ for i in script_list:
                           tags=["syn1", "male", "American"]))
 etor.close()
 ```
+
 Once we evaluate the audio files, we will email you the evaluation report within 12 hours.
 
 ## 👌 How to run the code testing
 
 Run this at the base directory:
+
 ```bash
 pytest
 ```
@@ -46,4 +51,5 @@ pytest
 For a deeper dive on all capabilities and details, please refer to [Documentation](https://www.podonos.com/docs).
 
 ## 📑 License
+
 [MIT License](https://github.com/podonos/podonos-pysdk/blob/main/LICENSE)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ license = "MIT"
 authors = [
     {name = "David Anderson", email = "david@podonos.com"}
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "glog",
     "packaging",
@@ -26,11 +26,11 @@ keywords = ["ai", "speech", "synthesis"]
 classifiers = [
     "Intended Audience :: Science/Research",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Multimedia :: Sound/Audio :: Analysis",
     "Topic :: Multimedia :: Sound/Audio :: Speech",
     "Topic :: Scientific/Engineering :: Artificial Intelligence"

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,6 +45,5 @@ tomli==2.0.1
 tqdm==4.67.1
 twine==5.1.0
 typing_extensions==4.12.1
-urllib3>=2.6.3,<3; python_version >= "3.10"
-urllib3>=1.25.4,<1.27; python_version < "3.10"
+urllib3>=2.6.3,<3
 zipp==3.19.2

--- a/tests/integration/run_integration_tests.sh
+++ b/tests/integration/run_integration_tests.sh
@@ -10,24 +10,6 @@ fi
 GREEN='\033[0;32m'
 NC='\033[0m'
 
-# Python 3.8
-conda create -y --name py38 python=3.8
-conda activate py38
-pip install -e .
-python ./integration_test_all.py
-conda activate base
-conda env remove -y --name py38
-echo -e "${GREEN}Successfully finished test on Python 3.8${NC}"
-
-# Python 3.9
-conda create -y --name py39 python=3.9
-conda activate py39
-pip install -e .
-python ./integration_test_all.py
-conda activate base
-conda env remove -y --name py39
-echo -e "${GREEN}Successfully finished test on Python 3.9${NC}"
-
 # Python 3.10
 conda create -y --name py310 python=3.10
 conda activate py310
@@ -54,5 +36,23 @@ python ./integration_test_all.py
 conda activate base
 conda env remove -y --name py312
 echo -e "${GREEN}Successfully finished test on Python 3.12${NC}"
+
+# Python 3.13
+conda create -y --name py313 python=3.13
+conda activate py313
+pip install -e .
+python ./integration_test_all.py
+conda activate base
+conda env remove -y --name py313
+echo -e "${GREEN}Successfully finished test on Python 3.13${NC}"
+
+# Python 3.14
+conda create -y --name py314 python=3.14
+conda activate py314
+pip install -e .
+python ./integration_test_all.py
+conda activate base
+conda env remove -y --name py314
+echo -e "${GREEN}Successfully finished test on Python 3.14${NC}"
 
 echo -e "${GREEN}Successfully finished all integration tests !!${NC}"


### PR DESCRIPTION
### 🚀 Pull Request Checklist

- [x] Summarize the changes made in this pull request.
- [x] Tested the changes to ensure they work as expected.
- [ ] Updated relevant documentation for the code changes.

### 📎 Related Issues

closes #271 

### 📋 Description

This pull request updates the minimum supported Python version to 3.10 and adds support for Python 3.13 and 3.14 across the project. It updates documentation, configuration, CI workflows, and integration tests to reflect these changes, while dropping support for Python 3.8 and 3.9.

**Python version support and configuration:**

* Updated the minimum required Python version from 3.8 to 3.10 in `pyproject.toml`, and added Python 3.13 and 3.14 to the list of supported versions in both the `classifiers` and `requires-python` fields. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L17-R17) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L29-R33)
* Updated GitHub Actions workflows (`test-mac.yml`, `test-ubuntu.yml`, `test-window.yml`) to run CI tests on Python 3.10, 3.11, 3.12, 3.13, and 3.14, dropping 3.8 and 3.9. [[1]](diffhunk://#diff-f10863b148dadb5fad68702c54bd78cb052731d073282a633ad09139040e51d5L17-R17) [[2]](diffhunk://#diff-42cc25851ea0b99c4a976081bfd68646a26a875e95ddcf54bca90aac163df7f3L17-R17) [[3]](diffhunk://#diff-14228d2389efcef13b86a0b6af2ef36f0d15df29fe456abfcdea244cbc6c54e9L17-R17)
* Updated integration test script to remove testing for Python 3.8 and 3.9 and add testing for Python 3.13 and 3.14. [[1]](diffhunk://#diff-e271a073b2c8e83908ac73ce99776d58bc6d190d585fec5f547f047a7746dff8L13-L30) [[2]](diffhunk://#diff-e271a073b2c8e83908ac73ce99776d58bc6d190d585fec5f547f047a7746dff8R40-R57)

**Documentation updates:**

* Updated the `README.md` to state that Python 3.10 or newer is required, and made minor formatting improvements. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R6-R12) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R25) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R38-R44) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R54)


