### PR TITLE
[Feature] Disable ranking feature and Singapore English

### DIFF
--- a/podonos/common/enum.py
+++ b/podonos/common/enum.py
@@ -11,7 +11,7 @@ class EvalType(Enum):
     NMOS = "NMOS"
     QMOS = "QMOS"
     P808 = "P808"
-    RANKING = "RANKING"
+    RANKING = "RANKING"  # Internal use only - not yet released to users
     SMOS = "SMOS"
     PREF = "PREF"
     CMOS = "CMOS"
@@ -60,15 +60,15 @@ class EvalType(Enum):
 
     @staticmethod
     def get_ranking_types() -> List["EvalType"]:
-        """Get all ranking evaluation types"""
-        return [EvalType.RANKING]
+        """Get all ranking evaluation types (not yet released)"""
+        return []  # RANKING not yet released
 
     @staticmethod
     def selected_from_template_evaluation_type(
         evaluation_type: str, batch_size: Optional[int] = None
     ) -> "EvalType":
         """
-        Map template.evaluation_type (e.g., 'SPEECH_NMOS', 'SPEECH_RANKING', 'CUSTOM') to EvalType.
+        Map template.evaluation_type (e.g., 'SPEECH_NMOS', 'CUSTOM') to EvalType.
         If evaluation_type is 'CUSTOM', batch_size is required to disambiguate.
         """
         mapping = {
@@ -80,7 +80,7 @@ class EvalType(Enum):
             "SPEECH_CMOS": EvalType.CMOS,
             "SPEECH_DMOS": EvalType.DMOS,
             "SPEECH_CSMOS": EvalType.CSMOS,
-            "SPEECH_RANKING": EvalType.RANKING,
+            # "SPEECH_RANKING": EvalType.RANKING,  # Not yet released
         }
         if evaluation_type in mapping:
             return mapping[evaluation_type]
@@ -99,7 +99,6 @@ class EvalType(Enum):
         - Single family -> all single types
         - Double family -> all double types
         - Triple family -> all triple types
-        - Ranking -> [RANKING]
         """
         if selected in EvalType.get_single_types():
             return EvalType.get_single_types()
@@ -107,9 +106,8 @@ class EvalType(Enum):
             return EvalType.get_double_types()
         if selected in EvalType.get_triple_types():
             return EvalType.get_triple_types()
-        if selected in EvalType.get_ranking_types():
-            return [EvalType.RANKING]
-        return [selected]
+        # Ranking not yet released
+        return []
 
     @staticmethod
     def is_single(type_str: str) -> bool:
@@ -123,8 +121,8 @@ class EvalType(Enum):
 
     @staticmethod
     def is_ranking(type_str: str) -> bool:
-        """Check if type is ranking"""
-        return EvalType(type_str) in EvalType.get_ranking_types()
+        """Check if type is ranking (not yet released)"""
+        return False  # RANKING not yet released
 
     @staticmethod
     def is_triple(type_str: str) -> bool:
@@ -142,21 +140,28 @@ class CustomType(Enum):
     SINGLE = "SINGLE"
     DOUBLE = "DOUBLE"
     SINGLE_REF = "SINGLE_REF"
-    RANKING = "RANKING"
+    RANKING = "RANKING"  # Internal use only - not yet released to users
 
     @classmethod
     def from_value(cls, value: str) -> "CustomType":
+        # Reject RANKING as not yet released
+        if value == "RANKING":
+            raise ValueError(
+                "Invalid custom_type: RANKING. "
+                "Use one of: SINGLE, DOUBLE, SINGLE_REF"
+            )
         for member in cls:
             if member.value == value:
                 return member
         raise ValueError(
             f"Invalid custom_type: {value}. "
-            f"Use one of: {', '.join([item.value for item in cls])}"
+            f"Use one of: SINGLE, DOUBLE, SINGLE_REF"
         )
 
     @staticmethod
     def values() -> List[str]:
-        return [item.value for item in CustomType]
+        # Exclude RANKING as it's not yet released
+        return [item.value for item in CustomType if item != CustomType.RANKING]
 
 
 class AIEvalType(Enum):
@@ -181,7 +186,7 @@ class Language(Enum):
     ENGLISH_AUSTRALIAN = "en-au"
     ENGLISH_CANADIAN = "en-ca"
     ENGLISH_INDIA = "en-in"
-    ENGLISH_SINGAPOREAN = "en-sg"
+    # ENGLISH_SINGAPOREAN = "en-sg"  # Not yet released
     PORTUGUESE_PORTUGAL = "pt-pt"
     PORTUGUESE_BRAZIL = "pt-br"
     KOREAN = "ko-kr"

--- a/podonos/core/client.py
+++ b/podonos/core/client.py
@@ -208,7 +208,7 @@ class Client:
             json: Template JSON as a dictionary. Optional if json_file is provided.
             json_file: Path to the JSON template file. Optional if json is provided.
             name: This evaluation name. Required.
-            custom_type: Type of evaluation (CustomType.SINGLE, CustomType.DOUBLE, CustomType.SINGLE_REF, or CustomType.RANKING). Also accepts string values.
+            custom_type: Type of evaluation (CustomType.SINGLE, CustomType.DOUBLE, or CustomType.SINGLE_REF). Also accepts string values.
             desc: Description of this evaluation. Optional.
             lan: Language for evaluation. Defaults to EvalConfigDefault.LAN.value.
             num_eval: The number of evaluators per file. Should be >=1.

--- a/podonos/core/config.py
+++ b/podonos/core/config.py
@@ -181,10 +181,10 @@ class EvalConfig:
             EvalType.CSMOS.value,
             EvalType.CUSTOM_SINGLE.value,
             EvalType.CUSTOM_DOUBLE.value,
-            EvalType.RANKING.value,
+            # RANKING not yet released
         ]:
             raise ValueError(
-                '"type" must be one of {NMOS, QMOS, SMOS, P808, PREF, CUSTOM_SINGLE, CUSTOM_DOUBLE, RANKING}. \n'
+                '"type" must be one of {NMOS, QMOS, SMOS, P808, PREF, CUSTOM_SINGLE, CUSTOM_DOUBLE}. \n'
                 + f"Do you want other evaluation types? Let us know at {PODONOS_CONTACT_EMAIL}"
             )
         return EvalType(eval_type)
@@ -197,7 +197,7 @@ class EvalConfig:
             Language.ENGLISH_BRITISH.value,
             Language.ENGLISH_CANADIAN.value,
             Language.ENGLISH_INDIA.value,
-            Language.ENGLISH_SINGAPOREAN.value,
+            # Language.ENGLISH_SINGAPOREAN.value,  # Not yet released
             Language.PORTUGUESE_PORTUGAL.value,
             Language.PORTUGUESE_BRAZIL.value,
             Language.KOREAN.value,
@@ -245,13 +245,11 @@ class EvalConfig:
             return 1
         elif EvalType.is_double(eval_type):
             return 2
-        elif EvalType.is_ranking(eval_type):
-            return 2
         elif EvalType.is_triple(eval_type):
             return 3
         else:
             raise ValueError(
-                '"eval_type" must be one of {NMOS, QMOS, P808, RANKING, SMOS, PREF, CSMOS, CUSTOM_SINGLE, CUSTOM_DOUBLE}.'
+                '"eval_type" must be one of {NMOS, QMOS, P808, SMOS, PREF, CSMOS, CUSTOM_SINGLE, CUSTOM_DOUBLE}.'
             )
 
     # TODO: allow floating point hours, e.g. 0.5.

--- a/podonos/core/evaluator.py
+++ b/podonos/core/evaluator.py
@@ -250,23 +250,17 @@ class Evaluator:
     def add_ranking_set(self, files: List[File]) -> None:
         """Add one ranking set (ordered candidates) for RANKING evaluation.
 
+        Note: This feature is not yet released.
+
         Constraints enforced across calls:
         - All groups must have the same number of files.
         - Order of model_tag must be identical across groups.
         - Files must be stimuli (no reference).
         """
-        if not self._initialized:
-            raise ValueError("Evaluator is not initialized")
-
-        self._validate_eval_type("add_ranking_set")
-
-        validated_files = self._file_validator.validate_files(
-            cast(List[Optional[File]], files)
+        raise NotImplementedError(
+            "RANKING evaluation type is not yet released. "
+            "Please use other evaluation types such as NMOS, QMOS, CMOS, etc."
         )
-        audio_group = self._file_transformer.transform_into_audio_group(validated_files)
-        self._ordered_file_groups.append(audio_group)
-        for audio in audio_group.audios:
-            self._upload_one_file(evaluation_id=self.get_evaluation_id(), audio=audio)
 
     def _validate_close(self) -> None:
         """Validate the state before closing.

--- a/podonos/evaluation/human_evaluation.py
+++ b/podonos/evaluation/human_evaluation.py
@@ -165,6 +165,13 @@ class HumanEvaluation:
         if template.batch_size is None:
             raise ValueError(f"Template with id {template_id} has no batch size")
 
+        # Reject RANKING templates as the feature is not yet released
+        if template.evaluation_type == "SPEECH_RANKING":
+            raise NotImplementedError(
+                "RANKING evaluation type is not yet released. "
+                "This template cannot be used at this time."
+            )
+
         # Determine eval_type from template.evaluation_type if present, else from batch_size
         selected_eval_type = EvalType.selected_from_template_evaluation_type(
             template.evaluation_type or "CUSTOM", batch_size=template.batch_size
@@ -226,7 +233,7 @@ class HumanEvaluation:
             json: Template JSON as a dictionary. Optional if json_file is provided.
             json_file: Path to the JSON template file. Optional if json is provided.
             name: This evaluation name. Required.
-            custom_type: Type of evaluation (CustomType.SINGLE, CustomType.DOUBLE, CustomType.SINGLE_REF, or CustomType.RANKING). Also accepts string values.
+            custom_type: Type of evaluation (CustomType.SINGLE, CustomType.DOUBLE, or CustomType.SINGLE_REF). Also accepts string values.
             desc: Description of this evaluation. Optional.
             lan: Language for evaluation. Defaults to EvalConfigDefault.LAN.value.
             num_eval: The number of evaluators per file. Should be >=1.
@@ -250,8 +257,15 @@ class HumanEvaluation:
                 custom_type = CustomType.from_value(custom_type)
             except ValueError:
                 raise ValueError(
-                    f"custom_type must be one of {', '.join(CustomType.values())}"
+                    "custom_type must be one of SINGLE, DOUBLE, or SINGLE_REF"
                 )
+
+        # Reject RANKING as it's not yet released
+        if custom_type == CustomType.RANKING:
+            raise NotImplementedError(
+                "RANKING evaluation type is not yet released. "
+                "Please use SINGLE, DOUBLE, or SINGLE_REF."
+            )
 
         if custom_type == CustomType.SINGLE:
             eval_type = EvalType.CUSTOM_SINGLE
@@ -262,12 +276,9 @@ class HumanEvaluation:
         elif custom_type == CustomType.SINGLE_REF:
             eval_type = EvalType.CMOS
             batch_size = 2
-        elif custom_type == CustomType.RANKING:
-            eval_type = EvalType.RANKING
-            batch_size = 2  # initial; will be adjusted on close() based on first ranking set size
         else:
             raise ValueError(
-                f"custom_type must be one of {', '.join(CustomType.values())}"
+                "custom_type must be one of SINGLE, DOUBLE, or SINGLE_REF"
             )
         # Load template data
         template_data = TemplateJsonLoader.load_json(json, json_file)

--- a/tests/common/test_enum.py
+++ b/tests/common/test_enum.py
@@ -13,7 +13,6 @@ class TestLanguageEnum(unittest.TestCase):
         self.assertEqual(Language.ENGLISH_AUSTRALIAN.value, "en-au")
         self.assertEqual(Language.ENGLISH_CANADIAN.value, "en-ca")
         self.assertEqual(Language.ENGLISH_INDIA.value, "en-in")
-        self.assertEqual(Language.ENGLISH_SINGAPOREAN.value, "en-sg")
         self.assertEqual(Language.PORTUGUESE_PORTUGAL.value, "pt-pt")
         self.assertEqual(Language.PORTUGUESE_BRAZIL.value, "pt-br")
         self.assertEqual(Language.KOREAN.value, "ko-kr")
@@ -43,7 +42,6 @@ class TestLanguageEnum(unittest.TestCase):
             ("en-au", Language.ENGLISH_AUSTRALIAN),
             ("en-ca", Language.ENGLISH_CANADIAN),
             ("en-in", Language.ENGLISH_INDIA),
-            ("en-sg", Language.ENGLISH_SINGAPOREAN),
         ]
 
         for value, expected_enum in english_variants:
@@ -158,7 +156,6 @@ class TestEvalTypeEnum(unittest.TestCase):
 
     def test_selected_from_template_evaluation_type_mapping(self):
         self.assertEqual(EvalType.selected_from_template_evaluation_type("SPEECH_NMOS"), EvalType.NMOS)
-        self.assertEqual(EvalType.selected_from_template_evaluation_type("SPEECH_RANKING"), EvalType.RANKING)
         self.assertEqual(EvalType.selected_from_template_evaluation_type("CUSTOM", batch_size=1), EvalType.CUSTOM_SINGLE)
         self.assertEqual(EvalType.selected_from_template_evaluation_type("CUSTOM", batch_size=2), EvalType.CUSTOM_DOUBLE)
 
@@ -166,7 +163,7 @@ class TestEvalTypeEnum(unittest.TestCase):
         self.assertEqual(set(EvalType.get_supported_types_for(EvalType.NMOS)), set(EvalType.get_single_types()))
         self.assertEqual(set(EvalType.get_supported_types_for(EvalType.PREF)), set(EvalType.get_double_types()))
         self.assertEqual(set(EvalType.get_supported_types_for(EvalType.CSMOS)), set(EvalType.get_triple_types()))
-        self.assertEqual(EvalType.get_supported_types_for(EvalType.RANKING), [EvalType.RANKING])
+        self.assertEqual(EvalType.get_supported_types_for(EvalType.RANKING), [])
 
 
 class TestAIEvalTypeEnum(unittest.TestCase):

--- a/tests/core/test_client.py
+++ b/tests/core/test_client.py
@@ -614,7 +614,7 @@ class TestClientFromTemplateJson(unittest.TestCase):
                 json=self.template_data, name="Test", custom_type="TRIPLE"
             )  # type: ignore
         self.assertIn(
-            "custom_type must be one of SINGLE, DOUBLE, SINGLE_REF, RANKING",
+            "custom_type must be one of SINGLE, DOUBLE, or SINGLE_REF",
             str(context.exception),
         )
 
@@ -680,15 +680,25 @@ class TestClientFromTemplateJson(unittest.TestCase):
 
     def test_create_evaluator_from_template_json_with_ranking_calls_human(self):
         mock_human = MagicMock()
-        mock_human.create_from_template_json.return_value = "EVAL"
+        # Configure mock to raise NotImplementedError for RANKING
+        mock_human.create_from_template_json.side_effect = NotImplementedError(
+            "RANKING evaluation type is not yet released. "
+            "Please use SINGLE, DOUBLE, or SINGLE_REF."
+        )
         self.client._human_evaluation = mock_human  # type: ignore
 
-        result = self.client.create_evaluator_from_template_json(
-            json={}, name="n", custom_type="RANKING"
-        )
+        # RANKING custom_type now raises NotImplementedError
+        with self.assertRaises(NotImplementedError) as context:
+            self.client.create_evaluator_from_template_json(
+                json={}, name="n", custom_type="RANKING"
+            )
+        self.assertIn("RANKING", str(context.exception))
+        self.assertIn("not yet released", str(context.exception))
 
-        self.assertEqual(result, "EVAL")
+        # Verify it was called with RANKING
         mock_human.create_from_template_json.assert_called_once()
+        call_kwargs = mock_human.create_from_template_json.call_args[1]
+        self.assertEqual(call_kwargs["custom_type"], "RANKING")
 
 
 class TestEvaluationClientApiKey(unittest.TestCase):
@@ -834,7 +844,7 @@ class TestClient(unittest.TestCase):
                 json=self.template_data, name="Test", custom_type="TRIPLE"
             )  # type: ignore
         self.assertIn(
-            "custom_type must be one of SINGLE, DOUBLE, SINGLE_REF, RANKING",
+            "custom_type must be one of SINGLE, DOUBLE, or SINGLE_REF",
             str(context.exception),
         )
 
@@ -924,6 +934,7 @@ class TestEvaluatorMethodValidation(unittest.TestCase):
         self.api_client.post = Mock(return_value=mock_response)
         self.api_client.put = Mock(return_value=mock_response)
 
+    @unittest.skip("RANKING not yet released")
     def test_ranking_evaluator_rejects_add_file(self):
         """Test RANKING evaluator rejects add_file method"""
         # Given
@@ -937,6 +948,7 @@ class TestEvaluatorMethodValidation(unittest.TestCase):
         self.assertIn("add_file", str(context.exception))
         self.assertIn("single file evaluation types", str(context.exception))
 
+    @unittest.skip("RANKING not yet released")
     def test_ranking_evaluator_rejects_add_files(self):
         """Test RANKING evaluator rejects add_files method"""
         # Given
@@ -952,7 +964,7 @@ class TestEvaluatorMethodValidation(unittest.TestCase):
         self.assertIn("comparison evaluation types", str(context.exception))
 
     def test_nmos_evaluator_rejects_add_ranking_set(self):
-        """Test NMOS evaluator rejects add_ranking_set method"""
+        """Test NMOS evaluator rejects add_ranking_set method (not yet released)"""
         # Given
         client = Client(api_client=self.api_client)
         evaluator = client._human_evaluation.create(type=EvalType.NMOS.value)  # type: ignore
@@ -961,11 +973,9 @@ class TestEvaluatorMethodValidation(unittest.TestCase):
             File(path=self.audio_path, model_tag="B"),
         ]
 
-        # When/Then
-        with self.assertRaises(ValueError) as context:
+        # When/Then - add_ranking_set raises NotImplementedError since RANKING is not yet released
+        with self.assertRaises(NotImplementedError):
             evaluator.add_ranking_set(files)
-        self.assertIn("add_ranking_set", str(context.exception))
-        self.assertIn("ranking evaluation types", str(context.exception))
 
     def test_nmos_evaluator_rejects_add_files(self):
         """Test NMOS evaluator rejects add_files method"""
@@ -1005,10 +1015,10 @@ class TestEvaluatorMethodValidation(unittest.TestCase):
         ]
 
         # When/Then
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaises(NotImplementedError) as context:
             evaluator.add_ranking_set(files)
-        self.assertIn("add_ranking_set", str(context.exception))
-        self.assertIn("ranking evaluation types", str(context.exception))
+        self.assertIn("RANKING", str(context.exception))
+        self.assertIn("not yet released", str(context.exception))
 
 
 if __name__ == "__main__":

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -31,8 +31,8 @@ class TestEvalConfig(unittest.TestCase):
         self.assertEqual(str(context.exception), '"name" must be longer than 1.')
 
     def test_validate_eval_type(self):
-        # Test valid types
-        valid_types = ["NMOS", "QMOS", "SMOS", "P808", "PREF", "CSMOS", "CUSTOM_SINGLE", "CUSTOM_DOUBLE", "RANKING"]
+        # Test valid types (RANKING removed as it's not yet released)
+        valid_types = ["NMOS", "QMOS", "SMOS", "P808", "PREF", "CSMOS", "CUSTOM_SINGLE", "CUSTOM_DOUBLE"]
         for eval_type in valid_types:
             result = self.eval_config._validate_eval_type(eval_type)  # type: ignore
             self.assertEqual(result.value, eval_type)

--- a/tests/core/test_evaluator.py
+++ b/tests/core/test_evaluator.py
@@ -827,6 +827,7 @@ class TestEvaluator(unittest.TestCase):
         self.assertEqual(len(self.evaluator._ordered_file_groups), 1)  # type: ignore
         self.assertEqual(mock_upload.call_count, 2)
 
+    @unittest.skip("RANKING not yet released")
     def test_add_ranking_set_raises_error_when_not_initialized(self):
         """Test add_ranking_set raises error when evaluator is not initialized"""
         # Given
@@ -841,6 +842,7 @@ class TestEvaluator(unittest.TestCase):
             self.evaluator.add_ranking_set(files)
         self.assertIn("Evaluator is not initialized", str(context.exception))
 
+    @unittest.skip("RANKING not yet released")
     def test_add_ranking_set_raises_error_for_wrong_eval_type(self):
         """Test add_ranking_set raises error for non-RANKING evaluation types"""
         # Given
@@ -855,6 +857,7 @@ class TestEvaluator(unittest.TestCase):
             self.evaluator.add_ranking_set(files)
         self.assertIn("ranking evaluation types", str(context.exception))
 
+    @unittest.skip("RANKING not yet released")
     @patch.object(Evaluator, "_upload_one_file")
     def test_add_ranking_set_processes_files_successfully(self, mock_upload: Mock):
         """Test add_ranking_set processes and uploads ranking files successfully"""
@@ -875,6 +878,7 @@ class TestEvaluator(unittest.TestCase):
         self.assertEqual(len(self.evaluator._ordered_file_groups), 1)  # type: ignore
         self.assertEqual(mock_upload.call_count, 2)
 
+    @unittest.skip("RANKING not yet released")
     @patch.object(Evaluator, "_upload_one_file")
     def test_add_ranking_set_rejects_inconsistent_model_tag_order(
         self, mock_upload: Mock
@@ -904,6 +908,7 @@ class TestEvaluator(unittest.TestCase):
             self.evaluator.add_ranking_set(files2)
         self.assertIn("identical model_tag order", str(context.exception))
 
+    @unittest.skip("RANKING not yet released")
     @patch.object(Evaluator, "_upload_one_file")
     def test_add_ranking_set_rejects_inconsistent_group_size(self, mock_upload: Mock):
         """Test add_ranking_set rejects groups with different number of files"""
@@ -932,6 +937,7 @@ class TestEvaluator(unittest.TestCase):
             self.evaluator.add_ranking_set(files2)
         self.assertIn("consistent group size", str(context.exception))
 
+    @unittest.skip("RANKING not yet released")
     @patch.object(Evaluator, "_upload_one_file")
     def test_add_ranking_set_rejects_single_file(self, mock_upload: Mock):
         """Test add_ranking_set rejects a group with only one file"""
@@ -949,6 +955,7 @@ class TestEvaluator(unittest.TestCase):
             self.evaluator.add_ranking_set(files)
         self.assertIn("at least two files", str(context.exception))
 
+    @unittest.skip("RANKING not yet released")
     @patch.object(Evaluator, "_upload_one_file")
     def test_add_ranking_set_rejects_reference_files(self, mock_upload: Mock):
         """Test add_ranking_set rejects files with is_ref=True"""
@@ -969,6 +976,7 @@ class TestEvaluator(unittest.TestCase):
             self.evaluator.add_ranking_set(files)
         self.assertIn("cannot include reference files", str(context.exception))
 
+    @unittest.skip("RANKING not yet released")
     @patch.object(Evaluator, "_upload_one_file")
     def test_add_ranking_set_maintains_order_across_multiple_groups(
         self, mock_upload: Mock
@@ -1008,6 +1016,7 @@ class TestEvaluator(unittest.TestCase):
         self.assertEqual(len(self.evaluator._ordered_file_groups), 3)  # type: ignore
         self.assertEqual(mock_upload.call_count, 9)  # 3 groups * 3 files each
 
+    @unittest.skip("RANKING not yet released")
     @patch.object(Evaluator, "_upload_one_file")
     def test_add_ranking_set_rejects_duplicate_model_tags_exact(
         self, mock_upload: Mock
@@ -1031,6 +1040,7 @@ class TestEvaluator(unittest.TestCase):
         self.assertIn("unique model_tags within a group", str(context.exception))
         self.assertIn("Duplicate found: 'AWS'", str(context.exception))
 
+    @unittest.skip("RANKING not yet released")
     @patch.object(Evaluator, "_upload_one_file")
     def test_add_ranking_set_rejects_duplicate_model_tags_case_insensitive(
         self, mock_upload: Mock
@@ -1054,6 +1064,7 @@ class TestEvaluator(unittest.TestCase):
         self.assertIn("unique model_tags within a group", str(context.exception))
         self.assertIn("case-insensitive", str(context.exception))
 
+    @unittest.skip("RANKING not yet released")
     @patch.object(Evaluator, "_upload_one_file")
     def test_add_ranking_set_rejects_duplicate_in_three_files(self, mock_upload: Mock):
         """Test add_ranking_set rejects duplicate model_tags in a group of three"""
@@ -1075,6 +1086,7 @@ class TestEvaluator(unittest.TestCase):
             self.evaluator.add_ranking_set(files)
         self.assertIn("unique model_tags within a group", str(context.exception))
 
+    @unittest.skip("RANKING not yet released")
     def test_update_ranking_batch_size_raises_error_when_no_groups(self):
         """Test _update_ranking_batch_size_before_upload raises error when no groups"""
         # Given
@@ -1085,6 +1097,7 @@ class TestEvaluator(unittest.TestCase):
             self.evaluator._update_ranking_batch_size_before_upload()  # type: ignore
         self.assertIn("at least one group with files", str(context.exception))
 
+    @unittest.skip("RANKING not yet released")
     def test_update_ranking_batch_size_raises_error_when_group_too_small(self):
         """Test _update_ranking_batch_size_before_upload raises error when group has < 2 files"""
         # Given
@@ -1109,6 +1122,7 @@ class TestEvaluator(unittest.TestCase):
             self.evaluator._update_ranking_batch_size_before_upload()  # type: ignore
         self.assertIn("at least two files per group", str(context.exception))
 
+    @unittest.skip("RANKING not yet released")
     def test_update_ranking_batch_size_updates_batch_size_successfully(self):
         """Test _update_ranking_batch_size_before_upload updates batch_size correctly"""
         # Given
@@ -1143,6 +1157,7 @@ class TestEvaluator(unittest.TestCase):
         self.assertEqual(payload["batch_size"], 3)
         self.assertEqual(self.evaluator._eval_config.eval_batch_size, 3)  # type: ignore
 
+    @unittest.skip("RANKING not yet released")
     @patch.object(Evaluator, "_upload_one_file")
     def test_update_specific_fields_receives_correct_batch_size_from_add_ranking_set(
         self, mock_upload: Mock
@@ -1184,6 +1199,7 @@ class TestEvaluator(unittest.TestCase):
         self.assertEqual(len(self.evaluator._ordered_file_groups[0].audios), 4)  # type: ignore
         self.assertEqual(self.evaluator._eval_config.eval_batch_size, 4)  # type: ignore
 
+    @unittest.skip("RANKING not yet released")
     @patch.object(Evaluator, "_upload_one_file")
     def test_update_specific_fields_batch_size_matches_first_group_size(
         self, mock_upload: Mock
@@ -1235,6 +1251,7 @@ class TestEvaluator(unittest.TestCase):
         self.assertEqual(len(self.evaluator._ordered_file_groups[0].audios), 5)  # type: ignore
         self.assertEqual(len(self.evaluator._ordered_file_groups[1].audios), 5)  # type: ignore
 
+    @unittest.skip("RANKING not yet released")
     @patch.object(Evaluator, "_upload_one_file")
     def test_update_specific_fields_payload_structure_for_ranking(
         self, mock_upload: Mock

--- a/tests/evaluation/test_human_evaluation.py
+++ b/tests/evaluation/test_human_evaluation.py
@@ -170,7 +170,7 @@ class TestHumanEvaluation(unittest.TestCase):
         self.assertEqual(evaluator._eval_config.eval_type, EvalType.CUSTOM_SINGLE)  # type: ignore
 
     def test_create_from_template_ranking_builds_ranking_evaluator(self):
-        """Test creating from RANKING template"""
+        """Test creating from RANKING template - now raises NotImplementedError"""
         # Given
         template = Template(
             id="template_id",
@@ -189,15 +189,13 @@ class TestHumanEvaluation(unittest.TestCase):
             eval_id
         )
 
-        # When
-        evaluator = self.human_eval.create_from_template(
-            name="Test Ranking", template_id="RANKING_TEMPLATE", num_eval=3
-        )
-
-        # Then
-        self.assertIsNotNone(evaluator)
-        self.assertEqual(evaluator._eval_config.eval_type, EvalType.RANKING)  # type: ignore
-        self.assertEqual(evaluator._supported_eval_types, [EvalType.RANKING])  # type: ignore
+        # When/Then - RANKING templates now raise NotImplementedError
+        with self.assertRaises(NotImplementedError) as context:
+            self.human_eval.create_from_template(
+                name="Test Ranking", template_id="RANKING_TEMPLATE", num_eval=3
+            )
+        self.assertIn("RANKING", str(context.exception))
+        self.assertIn("not yet released", str(context.exception))
 
     def test_create_from_template_with_cmos_template(self):
         """Test creating from CMOS template"""
@@ -266,7 +264,7 @@ class TestHumanEvaluation(unittest.TestCase):
                 json=template_json, name="Test Invalid", custom_type="INVALID"
             )  # type: ignore
         self.assertIn(
-            "custom_type must be one of SINGLE, DOUBLE, SINGLE_REF, RANKING",
+            "custom_type must be one of SINGLE, DOUBLE",
             str(context.exception),
         )
 


### PR DESCRIPTION
### 🚀 Pull Request Checklist

- [x] Summarize the changes made in this pull request.
- [x] Tested the changes to ensure they work as expected.
- [ ] Updated relevant documentation for the code changes.

### 📎 Related Issues

closes #283

### 📋 Description

This pull request disables and hides support for the "RANKING" evaluation type and the "ENGLISH_SINGAPOREAN" language variant throughout the codebase, as these features are not yet released. The changes ensure that users cannot select or use these options, update documentation and error messages accordingly, and adjust tests to reflect the unavailability of these features.

The most important changes are:

**Disabling RANKING Evaluation Type:**
- All references to the `RANKING` evaluation type in enums, mappings, and methods (such as `EvalType`, `CustomType`, and related validation functions) are marked as internal or commented out, and methods now return errors or empty results when RANKING is requested. Attempting to use RANKING now raises a `NotImplementedError` with a clear message. [[1]](diffhunk://#diff-a889aa0c05e8813de53f393019825110c8446f394c625a55b5a982be4089d37bL14-R14) [[2]](diffhunk://#diff-a889aa0c05e8813de53f393019825110c8446f394c625a55b5a982be4089d37bL63-R71) [[3]](diffhunk://#diff-a889aa0c05e8813de53f393019825110c8446f394c625a55b5a982be4089d37bL83-R83) [[4]](diffhunk://#diff-a889aa0c05e8813de53f393019825110c8446f394c625a55b5a982be4089d37bL102-R110) [[5]](diffhunk://#diff-a889aa0c05e8813de53f393019825110c8446f394c625a55b5a982be4089d37bL126-R125) [[6]](diffhunk://#diff-a889aa0c05e8813de53f393019825110c8446f394c625a55b5a982be4089d37bL145-R164) [[7]](diffhunk://#diff-34922e6cd18ee51a69b31b57f143299299924c3a5e40d1d4339e4ce78e3481e2R168-R174) [[8]](diffhunk://#diff-34922e6cd18ee51a69b31b57f143299299924c3a5e40d1d4339e4ce78e3481e2L253-R267) [[9]](diffhunk://#diff-34922e6cd18ee51a69b31b57f143299299924c3a5e40d1d4339e4ce78e3481e2L265-R281) [[10]](diffhunk://#diff-bc590ae368e24249245477fbad26cffa8a0298583b0aa1bb6ea2d269118acb11R253-L269) [[11]](diffhunk://#diff-b4f71256f433af14ff05004324f8d12a9a043533d489d1ea3f7503cdc771b2ceL184-R187) [[12]](diffhunk://#diff-b4f71256f433af14ff05004324f8d12a9a043533d489d1ea3f7503cdc771b2ceL248-R252) [[13]](diffhunk://#diff-1ba35d415000ec8b40de11bd18cb50b610230bc9b036c455134eef23ad8ee820L211-R211)

**Disabling ENGLISH_SINGAPOREAN Language Variant:**
- The `ENGLISH_SINGAPOREAN` language option is commented out in the `Language` enum and removed from validation and tests, making it unavailable for selection. [[1]](diffhunk://#diff-a889aa0c05e8813de53f393019825110c8446f394c625a55b5a982be4089d37bL184-R189) [[2]](diffhunk://#diff-b4f71256f433af14ff05004324f8d12a9a043533d489d1ea3f7503cdc771b2ceL200-R200) [[3]](diffhunk://#diff-20f3afbddd1ce28fa17a255208951d41ee9077fea07fe25b89b3c8908772c880L16) [[4]](diffhunk://#diff-20f3afbddd1ce28fa17a255208951d41ee9077fea07fe25b89b3c8908772c880L46)

**API and Documentation Updates:**
- Docstrings and error messages are updated to remove references to RANKING and ENGLISH_SINGAPOREAN, clarifying the available options for users. [[1]](diffhunk://#diff-1ba35d415000ec8b40de11bd18cb50b610230bc9b036c455134eef23ad8ee820L211-R211) [[2]](diffhunk://#diff-34922e6cd18ee51a69b31b57f143299299924c3a5e40d1d4339e4ce78e3481e2L229-R236)

**Test Adjustments:**
- Tests that previously checked for RANKING or ENGLISH_SINGAPOREAN are either removed, updated to expect errors, or skipped, ensuring test coverage matches the current feature set. [[1]](diffhunk://#diff-20f3afbddd1ce28fa17a255208951d41ee9077fea07fe25b89b3c8908772c880L161-R166) [[2]](diffhunk://#diff-c281c951d4f16fb0b3af0521ec95a0a29d60791bc5cec3afdb836536b04931fdL617-R617) [[3]](diffhunk://#diff-c281c951d4f16fb0b3af0521ec95a0a29d60791bc5cec3afdb836536b04931fdL683-R701) [[4]](diffhunk://#diff-c281c951d4f16fb0b3af0521ec95a0a29d60791bc5cec3afdb836536b04931fdL837-R847) [[5]](diffhunk://#diff-c281c951d4f16fb0b3af0521ec95a0a29d60791bc5cec3afdb836536b04931fdR937) [[6]](diffhunk://#diff-c281c951d4f16fb0b3af0521ec95a0a29d60791bc5cec3afdb836536b04931fdR951) [[7]](diffhunk://#diff-c281c951d4f16fb0b3af0521ec95a0a29d60791bc5cec3afdb836536b04931fdL955-R967) [[8]](diffhunk://#diff-c281c951d4f16fb0b3af0521ec95a0a29d60791bc5cec3afdb836536b04931fdL964-L968)

These changes collectively ensure that unreleased features are not accessible or visible to users, and the codebase remains clean and accurate regarding currently supported functionality.

