### PR TITLE
feat: add category parameter to flash_eval for noise_quality support

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,11 @@
+## 0.39.0
+
+- Add `category` parameter to `flash_eval()` to support noise_quality scoring
+- `FlashEvalResult` now exposes both `naturalness` and `noise_quality` fields;
+  the field populated depends on the requested category (default: naturalness)
+- Backward compatible: existing `flash_eval()` calls continue to return
+  naturalness scores; `result.noise_quality` is `None` for naturalness requests
+
 ## 0.38.1
 
 - Improve performance of silent audio detection using numpy vectorized operations

--- a/podonos/__init__.py
+++ b/podonos/__init__.py
@@ -2,6 +2,6 @@ from .core.file import File
 from .entity.flash_eval import FlashEvalResult
 from .sdk import Podonos, Client
 
-__version__ = "0.38.1"
+__version__ = "0.39.0"
 
 init = Podonos.init

--- a/podonos/core/client.py
+++ b/podonos/core/client.py
@@ -249,9 +249,18 @@ class Client:
             verify_batch_size=verify_batch_size,
         )
 
-    @validate_args(file_path=Rules.file_path_not_none, language=Rules.str_non_empty_or_none)
-    def flash_eval(self, file_path: str, language: Optional[str] = None) -> FlashEvalResult:
-        """Runs auto-evaluation on an audio file and returns the naturalness score.
+    @validate_args(
+        file_path=Rules.file_path_not_none,
+        language=Rules.str_non_empty_or_none,
+        category=Rules.str_non_empty_or_none,
+    )
+    def flash_eval(
+        self,
+        file_path: str,
+        language: Optional[str] = None,
+        category: Optional[str] = None,
+    ) -> FlashEvalResult:
+        """Runs auto-evaluation on an audio file and returns the score.
 
         Example:
             >>> import podonos
@@ -263,21 +272,31 @@ class Client:
             # For Spanish (es-es) audio:
             >>> result = client.flash_eval(file_path="path/to/audio_es.wav", language="es-es")
 
+            # For noise quality measurement (language is ignored when category="noise_quality"):
+            >>> result = client.flash_eval(file_path="path/to/audio.wav", category="noise_quality")
+            >>> print(result.noise_quality)
+            3.5
+
         Args:
             file_path: Path to the audio file to evaluate.
             language: Language code for model routing (e.g. 'es-es').
                       When omitted, the default en-us model is used.
-                      Supported: 'en-us', 'es-es'.
+                      Currently available: 'en-us', 'es-es'.
+                      Ignored when category is 'noise_quality'.
+            category: Evaluation category. Defaults to 'naturalness' when omitted.
+                      Currently available: 'naturalness', 'noise_quality'.
 
         Returns:
-            FlashEvalResult containing the naturalness score.
+            FlashEvalResult. For category='naturalness' the `naturalness` field
+            is populated; for category='noise_quality' the `noise_quality` field
+            is populated.
 
         Raises:
             ValueError: if this function is called before calling init().
         """
         if not self._initialized:
             raise ValueError("This function is called before initialization.")
-        return self._flash_eval_service.eval(file_path, language=language)
+        return self._flash_eval_service.eval(file_path, language=language, category=category)
 
     def get_evaluation_list(self) -> List[Dict[str, Any]]:
         """Gets a list of evaluations.

--- a/podonos/entity/flash_eval.py
+++ b/podonos/entity/flash_eval.py
@@ -7,17 +7,21 @@ from podonos.core.file import File
 @dataclass
 class FlashEvalResult:
     naturalness: Optional[float]
+    noise_quality: Optional[float]
     file: File
     id: Optional[str]
     message: Optional[str]
 
     @staticmethod
     def from_dict(data: Dict[str, Any], file: File, id: Optional[str] = None) -> "FlashEvalResult":
-        scores = data.get("scores", {})
-        naturalness = scores.get("naturalness") if isinstance(scores, dict) else None
+        raw_scores = data.get("scores")
+        scores = raw_scores if isinstance(raw_scores, dict) else {}
+        naturalness = scores.get("naturalness")
+        noise_quality = scores.get("noise_quality")
 
         return FlashEvalResult(
             naturalness=naturalness,
+            noise_quality=noise_quality,
             file=file,
             id=id,
             message=data.get("message"),

--- a/podonos/entity/flash_eval.py
+++ b/podonos/entity/flash_eval.py
@@ -7,10 +7,12 @@ from podonos.core.file import File
 @dataclass
 class FlashEvalResult:
     naturalness: Optional[float]
-    noise_quality: Optional[float]
     file: File
     id: Optional[str]
     message: Optional[str]
+    # noise_quality has a default so existing callers constructing
+    # FlashEvalResult(naturalness, file, id, message) remain compatible.
+    noise_quality: Optional[float] = None
 
     @staticmethod
     def from_dict(data: Dict[str, Any], file: File, id: Optional[str] = None) -> "FlashEvalResult":

--- a/podonos/service/flash_eval_service.py
+++ b/podonos/service/flash_eval_service.py
@@ -21,8 +21,17 @@ class FlashEvalService:
     def __init__(self, api_client: APIClient):
         self.api_client = api_client
 
-    @validate_args(file_path=Rules.file_path_not_none, language=Rules.str_non_empty_or_none)
-    def eval(self, file_path: str, language: Optional[str] = None) -> FlashEvalResult:
+    @validate_args(
+        file_path=Rules.file_path_not_none,
+        language=Rules.str_non_empty_or_none,
+        category=Rules.str_non_empty_or_none,
+    )
+    def eval(
+        self,
+        file_path: str,
+        language: Optional[str] = None,
+        category: Optional[str] = None,
+    ) -> FlashEvalResult:
         """Run auto-evaluation on an audio file.
 
         Executes the 3-step flow: init -> upload -> eval.
@@ -31,10 +40,15 @@ class FlashEvalService:
             file_path: Path to the audio file to evaluate.
             language: Language code for model routing (e.g. 'es-es').
                       When omitted, the default en-us model is used.
-                      Supported: 'en-us', 'es-es'.
+                      Currently available: 'en-us', 'es-es'.
+                      Ignored when category is 'noise_quality'.
+            category: Evaluation category. Defaults to 'naturalness' when omitted.
+                      Currently available: 'naturalness', 'noise_quality'.
 
         Returns:
-            FlashEvalResult with naturalness score and original file reference.
+            FlashEvalResult. For category='naturalness' the `naturalness` field
+            is populated; for category='noise_quality' the `noise_quality` field
+            is populated.
 
         Raises:
             HTTPError: If any API call fails.
@@ -46,7 +60,9 @@ class FlashEvalService:
         mimetype = get_content_type_by_filename(file_path)
 
         # Step 1: Initialize and get presigned URL
-        key, presigned_url = self._init(filename=filename, mimetype=mimetype, language=language)
+        key, presigned_url = self._init(
+            filename=filename, mimetype=mimetype, language=language, category=category
+        )
 
         # Step 2: Upload file to object storage
         self._upload(presigned_url=presigned_url, file_path=file_path, mimetype=mimetype)
@@ -56,8 +72,19 @@ class FlashEvalService:
 
         return FlashEvalResult.from_dict(response_data, file=file, id=key)
 
-    @validate_args(filename=Rules.str_non_empty, mimetype=Rules.str_non_empty, language=Rules.str_non_empty_or_none)
-    def _init(self, filename: str, mimetype: str, language: Optional[str] = None) -> Tuple[str, str]:
+    @validate_args(
+        filename=Rules.str_non_empty,
+        mimetype=Rules.str_non_empty,
+        language=Rules.str_non_empty_or_none,
+        category=Rules.str_non_empty_or_none,
+    )
+    def _init(
+        self,
+        filename: str,
+        mimetype: str,
+        language: Optional[str] = None,
+        category: Optional[str] = None,
+    ) -> Tuple[str, str]:
         """Step 1: Initialize upload and get presigned URL + key.
 
         Returns:
@@ -76,6 +103,8 @@ class FlashEvalService:
             }
             if language and language.strip():
                 payload["language"] = language.strip()
+            if category and category.strip():
+                payload["category"] = category.strip()
             response = self.api_client.post("flash/v1/init", data=payload)
             response.raise_for_status()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "podonos"
-version = "0.38.1"
+version = "0.39.0"
 description = "Managed evaluation for audio & speech"
 readme = "README.md"
 license = "MIT"

--- a/tests/core/test_client.py
+++ b/tests/core/test_client.py
@@ -1058,5 +1058,53 @@ class TestEvaluatorMethodValidation(unittest.TestCase):
         self.assertIn("ranking evaluation types", str(context.exception))
 
 
+@patch("os.path.isfile", return_value=True)
+@patch("os.access", return_value=True)
+class TestClientFlashEval(unittest.TestCase):
+    """Client-level forwarding tests for flash_eval to prevent regressions
+    in the public API surface (parameter passthrough to FlashEvalService)."""
+
+    def setUp(self):
+        self.valid_api_key = "test_key"
+        self.api_client = APIClient(self.valid_api_key, "http://testapi.com")
+        self.client = Client(self.api_client)
+        # Replace the real service with a mock so we can assert forwarding
+        self.client._flash_eval_service = MagicMock()
+        self.mock_result = MagicMock()
+        self.client._flash_eval_service.eval.return_value = self.mock_result
+
+    def test_flash_eval_forwards_file_path_only(self, mock_access, mock_isfile):
+        result = self.client.flash_eval("/path/to/audio.wav")
+        self.client._flash_eval_service.eval.assert_called_once_with(
+            "/path/to/audio.wav", language=None, category=None
+        )
+        self.assertIs(result, self.mock_result)
+
+    def test_flash_eval_forwards_language(self, mock_access, mock_isfile):
+        self.client.flash_eval("/path/to/audio.wav", language="es-es")
+        self.client._flash_eval_service.eval.assert_called_once_with(
+            "/path/to/audio.wav", language="es-es", category=None
+        )
+
+    def test_flash_eval_forwards_category(self, mock_access, mock_isfile):
+        self.client.flash_eval("/path/to/audio.wav", category="noise_quality")
+        self.client._flash_eval_service.eval.assert_called_once_with(
+            "/path/to/audio.wav", language=None, category="noise_quality"
+        )
+
+    def test_flash_eval_forwards_both_language_and_category(self, mock_access, mock_isfile):
+        self.client.flash_eval(
+            "/path/to/audio.wav", language="es-es", category="noise_quality"
+        )
+        self.client._flash_eval_service.eval.assert_called_once_with(
+            "/path/to/audio.wav", language="es-es", category="noise_quality"
+        )
+
+    def test_flash_eval_raises_when_not_initialized(self, mock_access, mock_isfile):
+        self.client._initialized = False
+        with self.assertRaises(ValueError):
+            self.client.flash_eval("/path/to/audio.wav")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/entity/test_flash_eval.py
+++ b/tests/entity/test_flash_eval.py
@@ -31,6 +31,7 @@ class TestFlashEvalResult(unittest.TestCase):
         data = {"message": None}
         result = FlashEvalResult.from_dict(data, file=file)
         self.assertIsNone(result.naturalness)
+        self.assertIsNone(result.noise_quality)
         self.assertIsNone(result.id)
         self.assertIsNone(result.message)
 
@@ -40,6 +41,7 @@ class TestFlashEvalResult(unittest.TestCase):
         file = self._create_file()
         result = FlashEvalResult.from_dict({}, file=file)
         self.assertIsNone(result.naturalness)
+        self.assertIsNone(result.noise_quality)
         self.assertIsNone(result.message)
 
     @patch("os.access", return_value=True)
@@ -49,6 +51,7 @@ class TestFlashEvalResult(unittest.TestCase):
         data = {"scores": "invalid"}
         result = FlashEvalResult.from_dict(data, file=file)
         self.assertIsNone(result.naturalness)
+        self.assertIsNone(result.noise_quality)
 
     @patch("os.access", return_value=True)
     @patch("os.path.isfile", return_value=True)
@@ -58,6 +61,20 @@ class TestFlashEvalResult(unittest.TestCase):
         result = FlashEvalResult.from_dict(data, file=file)
         self.assertEqual(result.file.path, "/home/user/recordings/speech.wav")
         self.assertEqual(result.file.model_tag, "flash_eval")
+
+    @patch("os.access", return_value=True)
+    @patch("os.path.isfile", return_value=True)
+    def test_from_dict_with_noise_quality(self, mock_isfile, mock_access):
+        file = self._create_file()
+        data = {
+            "scores": {"noise_quality": 3.5},
+            "message": None,
+        }
+        result = FlashEvalResult.from_dict(data, file=file, id="eval-456")
+        self.assertIsNone(result.naturalness)
+        self.assertEqual(result.noise_quality, 3.5)
+        self.assertEqual(result.id, "eval-456")
+        self.assertIsNone(result.message)
 
 
 if __name__ == "__main__":

--- a/tests/service/test_flash_eval_service.py
+++ b/tests/service/test_flash_eval_service.py
@@ -265,6 +265,87 @@ class TestFlashEvalService(unittest.TestCase):
         init_payload = init_call[1]["data"] if "data" in init_call[1] else init_call[0][1]
         self.assertNotIn("language", init_payload)
 
+    def _setup_noise_quality_eval_response(self, noise_quality=3.5):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "scores": {"noise_quality": noise_quality},
+            "files": [
+                {"filename": "test.wav", "filetype": "TARGET_1", "mimetype": "audio/wav"}
+            ],
+            "message": None,
+        }
+        mock_response.raise_for_status.return_value = None
+        return mock_response
+
+    @patch("os.path.getsize", return_value=1024)
+    @patch("os.path.isfile", return_value=True)
+    @patch("os.access", return_value=True)
+    @patch("builtins.open", mock_open(read_data=b"fake audio data"))
+    def test_eval_with_category_noise_quality_passes_to_init(self, mock_access, mock_isfile, mock_getsize):
+        """Test that category parameter is included in init payload."""
+        init_response = self._setup_init_response()
+        upload_response = self._setup_upload_response()
+        eval_response = self._setup_noise_quality_eval_response(noise_quality=3.5)
+
+        self.mock_api_client.post.side_effect = [init_response, eval_response]
+        self.mock_api_client.external_put.return_value = upload_response
+
+        result = self.service.eval("/path/to/test.wav", category="noise_quality")
+
+        # Result has noise_quality, not naturalness
+        self.assertEqual(result.noise_quality, 3.5)
+        self.assertIsNone(result.naturalness)
+
+        # Verify init payload includes category and does NOT include language
+        init_call = self.mock_api_client.post.call_args_list[0]
+        init_payload = init_call[1]["data"] if "data" in init_call[1] else init_call[0][1]
+        self.assertEqual(init_payload["category"], "noise_quality")
+        self.assertNotIn("language", init_payload)
+
+    @patch("os.path.getsize", return_value=1024)
+    @patch("os.path.isfile", return_value=True)
+    @patch("os.access", return_value=True)
+    @patch("builtins.open", mock_open(read_data=b"fake audio data"))
+    def test_eval_with_category_and_language_forwards_both(self, mock_access, mock_isfile, mock_getsize):
+        """Test that both category and language are forwarded to server (server ignores language when category=noise_quality)."""
+        init_response = self._setup_init_response()
+        upload_response = self._setup_upload_response()
+        eval_response = self._setup_noise_quality_eval_response(noise_quality=3.5)
+
+        self.mock_api_client.post.side_effect = [init_response, eval_response]
+        self.mock_api_client.external_put.return_value = upload_response
+
+        self.service.eval("/path/to/test.wav", language="es-es", category="noise_quality")
+
+        # Verify both are forwarded — server owns the precedence logic
+        init_call = self.mock_api_client.post.call_args_list[0]
+        init_payload = init_call[1]["data"] if "data" in init_call[1] else init_call[0][1]
+        self.assertEqual(init_payload["category"], "noise_quality")
+        self.assertEqual(init_payload["language"], "es-es")
+
+    @patch("os.path.getsize", return_value=1024)
+    @patch("os.path.isfile", return_value=True)
+    @patch("os.access", return_value=True)
+    @patch("builtins.open", mock_open(read_data=b"fake audio data"))
+    def test_eval_without_category_omits_from_init(self, mock_access, mock_isfile, mock_getsize):
+        """Test that category is not in init payload when omitted."""
+        init_response = self._setup_init_response()
+        upload_response = self._setup_upload_response()
+        eval_response = self._setup_eval_response(naturalness=4.1)
+
+        self.mock_api_client.post.side_effect = [init_response, eval_response]
+        self.mock_api_client.external_put.return_value = upload_response
+
+        result = self.service.eval("/path/to/test.wav")
+
+        self.assertEqual(result.naturalness, 4.1)
+
+        # Verify init payload does NOT include category
+        init_call = self.mock_api_client.post.call_args_list[0]
+        init_payload = init_call[1]["data"] if "data" in init_call[1] else init_call[0][1]
+        self.assertNotIn("category", init_payload)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Add optional `category` parameter to `flash_eval()` to support noise_quality scoring
- When `category=\"noise_quality\"` is passed, the backend routes to the Vertex AI noise endpoint
- `FlashEvalResult` now exposes both `naturalness` and `noise_quality` fields — the field populated depends on the requested category
- Backward compatible: existing `flash_eval()` calls continue to work unchanged
- Bump version 0.38.1 → 0.39.0

## Usage
```python
import podonos

client = podonos.init(api_key=\"YOUR_API_KEY\")

# Existing (naturalness, unchanged)
result = client.flash_eval(\"audio.wav\")
print(result.naturalness)    # 3.58
print(result.noise_quality)  # None

# New (noise_quality; language is ignored when category=\"noise_quality\")
result = client.flash_eval(\"audio.wav\", category=\"noise_quality\")
print(result.naturalness)    # None
print(result.noise_quality)  # 3.5
```

## Backend counterpart
This SDK change corresponds to the backend PR [podonos/apple#5500](https://github.com/podonos/apple/pull/5500), already merged and deployed to production.

## Test plan
- [x] Unit tests: 484 passed, 7 skipped (483 existing + new category tests)
- [x] New tests:
  - `test_eval_with_category_noise_quality_passes_to_init` — category forwarding + language absence assertion
  - `test_eval_without_category_omits_from_init` — category omission
  - `test_eval_with_category_and_language_forwards_both` — both forwarded, server owns precedence
  - `test_from_dict_with_noise_quality` — response parsing
- [x] Backward compatibility: existing naturalness flow unchanged; all existing tests pass
- [x] Prod API validated manually (backend PR) with `category=\"noise_quality\"` → `{\"noise_quality\": 3.5}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)