### PR TITLE
feat: add script_tags support to File class and evaluation API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,6 @@ template_ranking.json
 
 # OMC
 .omc/
+
+# Superset worktree metadata
+.superset/

--- a/podonos/core/evaluator.py
+++ b/podonos/core/evaluator.py
@@ -194,6 +194,12 @@ class Evaluator:
 
         self._validate_eval_type("add_file")
 
+        if file.script_tags:
+            raise ValueError(
+                "script_tags is only supported for RANKING evaluations. "
+                "Use add_ranking_set() instead."
+            )
+
         file = self._file_validator.validate_file(file)
         audio_group = self._file_transformer.transform_into_audio_group([file])
         self._ordered_file_groups.append(audio_group)
@@ -239,6 +245,12 @@ class Evaluator:
             raise ValueError("Evaluator is not initialized")
 
         self._validate_eval_type("add_files")
+
+        if any(f.script_tags for f in [file0, file1, file2] if f is not None):
+            raise ValueError(
+                "script_tags is only supported for RANKING evaluations. "
+                "Use add_ranking_set() instead."
+            )
 
         files = self._file_validator.validate_files([file0, file1, file2])
         audio_group = self._file_transformer.transform_into_audio_group(files)

--- a/podonos/core/file.py
+++ b/podonos/core/file.py
@@ -36,23 +36,23 @@ class File:
         path: str,
         model_tag: str,
         tags: List[str] = [],
-        script_tags: List[str] = [],
         script: Optional[str] = None,
         is_ref: bool = False,
         meta_data: Dict[str, Any] = {},
+        script_tags: List[str] = [],
     ) -> None:
         """
         Args:
             path: Path to the file to evaluate. Required.
             model_tag: String that represents the model or group. Required.
             tags: A list of string for file. Optional.
-            script_tags: A list of script-level tags. Only used for RANKING evaluations. Optional.
             script: Script of the input audio in text. Optional.
             is_ref: True if this file is to be a reference for an evaluation type that requires a reference.
                     Optional. Default is False.
             meta_data: Arbitrary key-value meta data. Keys must be strings.
                        Values must be JSON-primitive types (str, int, float, bool, None).
                        Iterable types such as list, tuple, set, dict are not allowed.
+            script_tags: A list of script-level tags. Only used for RANKING evaluations. Optional.
         """
         log.check_ne(path, "")  # type: ignore
         log.check_ne(model_tag, "")  # type: ignore
@@ -60,10 +60,10 @@ class File:
         self._path = self._validate_path(path)
         self._model_tag = self._validate_model_tag(model_tag)
         self._tags = self._set_tags(tags)
-        self._script_tags = self._set_tags(script_tags)
         self._script = self._validate_script(script)
         self._is_ref = self._validate_is_ref(is_ref)
         self._meta_data = self._validate_meta_data(meta_data)
+        self._script_tags = self._set_tags(script_tags)
 
     def __repr__(self) -> str:
         return f"File(path='{self._path}')"

--- a/podonos/core/file.py
+++ b/podonos/core/file.py
@@ -36,6 +36,7 @@ class File:
         path: str,
         model_tag: str,
         tags: List[str] = [],
+        script_tags: List[str] = [],
         script: Optional[str] = None,
         is_ref: bool = False,
         meta_data: Dict[str, Any] = {},
@@ -45,6 +46,7 @@ class File:
             path: Path to the file to evaluate. Required.
             model_tag: String that represents the model or group. Required.
             tags: A list of string for file. Optional.
+            script_tags: A list of script-level tags. Only used for RANKING evaluations. Optional.
             script: Script of the input audio in text. Optional.
             is_ref: True if this file is to be a reference for an evaluation type that requires a reference.
                     Optional. Default is False.
@@ -58,6 +60,7 @@ class File:
         self._path = self._validate_path(path)
         self._model_tag = self._validate_model_tag(model_tag)
         self._tags = self._set_tags(tags)
+        self._script_tags = self._set_tags(script_tags)
         self._script = self._validate_script(script)
         self._is_ref = self._validate_is_ref(is_ref)
         self._meta_data = self._validate_meta_data(meta_data)
@@ -76,6 +79,10 @@ class File:
     @property
     def tags(self) -> List[str]:
         return self._tags
+
+    @property
+    def script_tags(self) -> List[str]:
+        return self._script_tags
 
     @property
     def script(self) -> Optional[str]:
@@ -719,6 +726,7 @@ class Audio(File):
         remote_object_name=Rules.str_non_empty,
         script=Rules.str_not_none_or_none,
         tags=Rules.list_not_none,
+        script_tags=Rules.list_not_none,
         model_tag=Rules.str_non_empty,
         is_ref=Rules.bool_not_none,
         meta_data=Rules.dict_not_none,
@@ -739,8 +747,17 @@ class Audio(File):
         type: QuestionFileType,
         order_in_group: int,
         meta_data: Dict[str, Any] = {},
+        script_tags: List[str] = [],
     ):
-        super().__init__(path, model_tag, tags, script, is_ref, meta_data)
+        super().__init__(
+            path=path,
+            model_tag=model_tag,
+            tags=tags,
+            script_tags=script_tags,
+            script=script,
+            is_ref=is_ref,
+            meta_data=meta_data,
+        )
         self._name = name
         self._remote_object_name = remote_object_name
         self._group = group
@@ -791,6 +808,7 @@ class Audio(File):
             remote_object_name=remote_path,
             script=file.script,
             tags=file.tags,
+            script_tags=file.script_tags,
             model_tag=file.model_tag,
             is_ref=file.is_ref if file.is_ref else False,
             meta_data=file.meta_data,
@@ -853,6 +871,7 @@ class Audio(File):
             "model_tag": self._model_tag,
             "is_ref": self._is_ref,
             "tag": self._tags,
+            "script_tag": self._script_tags,
             "type": self._type,
             "script": self._script,
             "meta_data": self._meta_data,
@@ -867,6 +886,7 @@ class Audio(File):
             "duration": self._metadata.duration_in_ms,
             "model_tag": self._model_tag,
             "tags": self._tags,
+            "script_tags": self._script_tags,
             "type": self._type,
             "script": self._script,
             "meta_data": self._meta_data,

--- a/tests/core/test_audio.py
+++ b/tests/core/test_audio.py
@@ -257,6 +257,91 @@ class TestAudio(unittest.TestCase):
         self.assertEqual(file_dict["order_in_group"], 1)
 
 
+    def test_should_include_script_tags_in_create_file_dict(self):
+        # Given
+        audio = Audio(
+            path=self.test_wav,
+            name="speech_two_ch1.wav",
+            remote_object_name="remote/path.wav",
+            script="test script",
+            tags=["test"],
+            model_tag="test_model",
+            is_ref=False,
+            group="test_group",
+            type=QuestionFileType.STIMULUS,
+            order_in_group=0,
+            script_tags=["address", "greeting"],
+        )
+
+        # When
+        file_dict = audio.to_create_file_dict()
+
+        # Then
+        self.assertEqual(file_dict["script_tags"], ["address", "greeting"])
+
+    def test_should_include_script_tag_in_to_dict(self):
+        # Given
+        audio = Audio(
+            path=self.test_wav,
+            name="speech_two_ch1.wav",
+            remote_object_name="remote/path.wav",
+            script="test script",
+            tags=["test"],
+            model_tag="test_model",
+            is_ref=False,
+            group="test_group",
+            type=QuestionFileType.STIMULUS,
+            order_in_group=0,
+            script_tags=["address"],
+        )
+
+        # When
+        d = audio.to_dict()
+
+        # Then
+        self.assertEqual(d["script_tag"], ["address"])
+
+    def test_should_default_script_tags_to_empty_list_in_dicts(self):
+        # Given
+        audio = Audio(
+            path=self.test_wav,
+            name="speech_two_ch1.wav",
+            remote_object_name="remote/path.wav",
+            script="test script",
+            tags=["test"],
+            model_tag="test_model",
+            is_ref=False,
+            group="test_group",
+            type=QuestionFileType.STIMULUS,
+            order_in_group=0,
+        )
+
+        # When / Then
+        self.assertEqual(audio.to_create_file_dict()["script_tags"], [])
+        self.assertEqual(audio.to_dict()["script_tag"], [])
+
+    def test_from_file_should_preserve_script_tags(self):
+        # Given
+        file = File(
+            path=self.test_wav,
+            model_tag="test_model",
+            tags=["test"],
+            script_tags=["address", "greeting"],
+        )
+
+        # When
+        audio = Audio.from_file(
+            file=file,
+            creation_timestamp="2026-01-01",
+            group="test_group",
+            type=QuestionFileType.STIMULUS,
+            order_in_group=0,
+        )
+
+        # Then
+        self.assertEqual(audio.script_tags, ["address", "greeting"])
+
+
 class TestAudioGroup(unittest.TestCase):
     def setUp(self):
         self.test_dir = os.path.dirname(__file__)

--- a/tests/core/test_evaluator.py
+++ b/tests/core/test_evaluator.py
@@ -1362,5 +1362,72 @@ class TestEvaluator(unittest.TestCase):
         self.assertEqual(eval_config_max.verify_batch_size, 1000)
 
 
+    # ----------------------------
+    # script_tags RANKING-only enforcement tests
+    # ----------------------------
+    @patch.object(Evaluator, "_upload_one_file")
+    def test_add_file_rejects_non_empty_script_tags(self, mock_upload: Mock):
+        """Test add_file raises ValueError when file has non-empty script_tags"""
+        # Given
+        self.evaluator._eval_config._eval_type = EvalType.NMOS  # type: ignore
+        self.evaluator._evaluation = self.mock_evaluation  # type: ignore
+        file = File(path=self.test_wav, model_tag="test_model", script_tags=["address"])
+
+        # When/Then
+        with self.assertRaises(ValueError) as context:
+            self.evaluator.add_file(file)
+        self.assertIn("script_tags is only supported for RANKING", str(context.exception))
+
+    @patch.object(Evaluator, "_upload_one_file")
+    def test_add_file_allows_empty_script_tags(self, mock_upload: Mock):
+        """Test add_file succeeds when file has empty script_tags (regression guard)"""
+        # Given
+        self.evaluator._eval_config._eval_type = EvalType.NMOS  # type: ignore
+        self.evaluator._evaluation = self.mock_evaluation  # type: ignore
+        file = File(path=self.test_wav, model_tag="test_model", script_tags=[])
+
+        # When
+        self.evaluator.add_file(file)
+
+        # Then
+        self.assertEqual(len(self.evaluator._ordered_file_groups), 1)  # type: ignore
+        mock_upload.assert_called_once()
+
+    @patch.object(Evaluator, "_upload_one_file")
+    def test_add_files_rejects_non_empty_script_tags(self, mock_upload: Mock):
+        """Test add_files raises ValueError when any file has non-empty script_tags"""
+        # Given
+        self.evaluator._eval_config._eval_type = EvalType.PREF  # type: ignore
+        self.evaluator._supported_eval_types = [EvalType.PREF]  # type: ignore
+        self.evaluator._evaluation = self.mock_evaluation  # type: ignore
+        file0 = File(path=self.test_wav, model_tag="model1", script_tags=["address"])
+        file1 = File(path=self.test_wav, model_tag="model2")
+
+        # When/Then
+        with self.assertRaises(ValueError) as context:
+            self.evaluator.add_files(file0, file1)
+        self.assertIn("script_tags is only supported for RANKING", str(context.exception))
+
+    @patch.object(Evaluator, "_upload_one_file")
+    def test_add_ranking_set_allows_script_tags(self, mock_upload: Mock):
+        """Test add_ranking_set succeeds with script_tags"""
+        # Given
+        self.evaluator._eval_config._eval_type = EvalType.RANKING  # type: ignore
+        self.evaluator._eval_config._eval_batch_size = 2  # type: ignore
+        self.evaluator._supported_eval_types = [EvalType.RANKING]  # type: ignore
+        self.evaluator._evaluation = self.mock_evaluation  # type: ignore
+        files = [
+            File(path=self.test_wav, model_tag="A", script_tags=["address"]),
+            File(path=self.test_wav, model_tag="B", script_tags=["address"]),
+        ]
+
+        # When
+        self.evaluator.add_ranking_set(files)
+
+        # Then
+        self.assertEqual(len(self.evaluator._ordered_file_groups), 1)  # type: ignore
+        self.assertEqual(mock_upload.call_count, 2)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/core/test_file.py
+++ b/tests/core/test_file.py
@@ -951,6 +951,34 @@ class TestFile(unittest.TestCase):
         self.assertIn("ModelB", model_tags)
 
 
+class TestFileScriptTags(unittest.TestCase):
+    """Test cases for File.script_tags parameter"""
+
+    def setUp(self):
+        self.test_dir = os.path.dirname(__file__)
+        self.test_wav = os.path.join(self.test_dir, "speech_two_ch1.wav")
+
+    def test_file_default_script_tags_is_empty_list(self):
+        """File without script_tags should default to []"""
+        f = File(path=self.test_wav, model_tag="test_model")
+        self.assertEqual(f.script_tags, [])
+
+    def test_file_script_tags_stores_values(self):
+        """File with script_tags should store them correctly"""
+        f = File(path=self.test_wav, model_tag="test_model", script_tags=["a", "b"])
+        self.assertEqual(f.script_tags, ["a", "b"])
+
+    def test_file_script_tags_deduplicates(self):
+        """File with duplicate script_tags should deduplicate them"""
+        f = File(path=self.test_wav, model_tag="test_model", script_tags=["a", "a", "b"])
+        self.assertEqual(f.script_tags, ["a", "b"])
+
+    def test_file_script_tags_coerces_types(self):
+        """File with non-string script_tags should coerce to strings"""
+        f = File(path=self.test_wav, model_tag="test_model", script_tags=[1, 2.0])
+        self.assertEqual(f.script_tags, ["1", "2.0"])
+
+
 class TestAudioMeta(unittest.TestCase):
     """Test cases for AudioMeta class and format detection functionality"""
 

--- a/tests/integration/ranking_script_tags_test.py
+++ b/tests/integration/ranking_script_tags_test.py
@@ -1,0 +1,151 @@
+"""
+E2E test: RANKING evaluation with script_tags.
+
+Verifies that script_tags set via the SDK are correctly sent to the backend
+through the PUT evaluation-files API.
+
+Example:
+    python tests/integration/ranking_script_tags_test.py --api_key=<KEY>
+    python tests/integration/ranking_script_tags_test.py --api_key=<KEY> --base_url=https://dev.podonosapi.com
+"""
+
+import argparse
+import sys
+from datetime import datetime
+
+import podonos
+from podonos import *
+from podonos.core.base import *
+
+_PODONOS_API_BASE_URL = "https://dev.podonosapi.com"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="E2E test: RANKING with script_tags")
+    parser.add_argument("--api_key", required=True, help="API key string.")
+    parser.add_argument(
+        "--base_url",
+        required=False,
+        default=_PODONOS_API_BASE_URL,
+        help="Base URL for the backend APIs.",
+    )
+    args = parser.parse_args()
+
+    log.info(f"Python version: {sys.version}")
+    log.info(f"Podonos package version: {podonos.__version__}")
+    log.info(f"Base URL: {args.base_url}")
+
+    client = podonos.init(api_key=args.api_key, api_url=args.base_url)
+
+    name_prefix = datetime.today().strftime("%Y%m%d%H%M%S")
+
+    # --- Test 1: RANKING with script_tags ---
+    log.info("=== Test 1: RANKING with script_tags ===")
+    etor = client.create_evaluator(
+        name=f"{name_prefix}_ranking_script_tags",
+        desc="E2E test for script_tags support in RANKING evaluation",
+        type="RANKING",
+        lan="en-us",
+        num_eval=1,
+        due_hours=12,
+        auto_start=False,
+    )
+    evaluation_id = etor.get_evaluation_id()
+    log.info(f"Evaluation id: {evaluation_id}")
+
+    # Group 1: "address" script tag
+    etor.add_ranking_set([
+        File(
+            path="tests/core/speech_two_ch1.wav",
+            model_tag="ModelA",
+            tags=["english"],
+            script_tags=["address"],
+            script="Please tell me your address.",
+        ),
+        File(
+            path="tests/core/speech_two_ch2.wav",
+            model_tag="ModelB",
+            tags=["english"],
+            script_tags=["address"],
+            script="Please tell me your address.",
+        ),
+    ])
+    log.info("Group 1 added (script_tags=['address'])")
+
+    # Group 2: "greeting" script tag
+    etor.add_ranking_set([
+        File(
+            path="tests/core/speech_two_ch1.wav",
+            model_tag="ModelA",
+            tags=["english"],
+            script_tags=["greeting"],
+            script="Hello, how are you?",
+        ),
+        File(
+            path="tests/core/speech_two_ch2.wav",
+            model_tag="ModelB",
+            tags=["english"],
+            script_tags=["greeting"],
+            script="Hello, how are you?",
+        ),
+    ])
+    log.info("Group 2 added (script_tags=['greeting'])")
+
+    # Group 3: no script_tags (backward compatibility)
+    etor.add_ranking_set([
+        File(
+            path="tests/core/speech_two_ch1.wav",
+            model_tag="ModelA",
+            tags=["english"],
+            script="Good morning.",
+        ),
+        File(
+            path="tests/core/speech_two_ch2.wav",
+            model_tag="ModelB",
+            tags=["english"],
+            script="Good morning.",
+        ),
+    ])
+    log.info("Group 3 added (no script_tags, backward compat)")
+
+    etor.close()
+    log.info(f"RANKING evaluation closed successfully. ID: {evaluation_id}")
+
+    # --- Test 2: RANKING with multiple script_tags per file ---
+    log.info("=== Test 2: RANKING with multiple script_tags ===")
+    etor2 = client.create_evaluator(
+        name=f"{name_prefix}_ranking_multi_script_tags",
+        desc="E2E test for multiple script_tags",
+        type="RANKING",
+        lan="en-us",
+        num_eval=1,
+        due_hours=12,
+        auto_start=False,
+    )
+    evaluation_id2 = etor2.get_evaluation_id()
+    log.info(f"Evaluation id: {evaluation_id2}")
+
+    etor2.add_ranking_set([
+        File(
+            path="tests/core/speech_two_ch1.wav",
+            model_tag="ModelA",
+            tags=["english", "male"],
+            script_tags=["address", "formal"],
+        ),
+        File(
+            path="tests/core/speech_two_ch2.wav",
+            model_tag="ModelB",
+            tags=["english", "male"],
+            script_tags=["address", "casual"],
+        ),
+    ])
+    log.info("Group added with multiple + different script_tags per file")
+
+    etor2.close()
+    log.info(f"RANKING evaluation closed successfully. ID: {evaluation_id2}")
+
+    log.info("=== All E2E tests passed ===")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Context
When creating RANKING evaluations via the SDK, there was no way to set script-level tags (`script_tags`) programmatically. Users had to manually assign them in the UI after file upload.

## Problem
The `File` class and the file creation API payload did not include a `script_tags` field, so script tags could not be set during file upload via the SDK.

## Solution
- Added an optional `script_tags` parameter to the `File` class with the same validation rules as `tags` (dedup, type coercion)
- Wired `script_tags` through `Audio.from_file()`, `to_dict()`, and `to_create_file_dict()` so the field is included in the API payload
- Added RANKING-only enforcement: `add_file()` and `add_files()` reject non-empty `script_tags` with `ValueError`
- Converted `Audio.__init__()` `super()` call to keyword arguments for robustness

## Test Plan
- [x] Unit tests pass: `pytest tests/core/test_file.py tests/core/test_audio.py tests/core/test_evaluator.py`
- [x] Full test suite passes: `pytest tests/`
- [x] E2E integration test: `python tests/integration/ranking_script_tags_test.py --api_key=<KEY>`
- [x] Backward compatibility: existing code without `script_tags` works unchanged

---
Generated with [Claude Code](https://claude.ai/claude-code)