### PR TITLE
build(deps): upgrade pytest to 9.0.3 for CVE-2025-71176

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ podonos==0.20.0
 pycparser==2.22
 pyparsing==2.4.6
 pyproject_hooks==1.1.0
-pytest==8.2.2
+pytest==9.0.3
 python-dateutil==2.9.0.post0
 python-gflags==3.1.2
 readme_renderer==43.0


### PR DESCRIPTION
## Context
Dependabot alert #10 flagged pytest as vulnerable in the project's `requirements.txt`.

## Problem
pytest 8.2.2 has a vulnerable tmpdir handling issue (CVE-2025-71176, medium severity). On UNIX systems, pytest relies on `/tmp/pytest-of-{user}` directories with insecure permissions, allowing local users to cause denial of service or possibly gain privileges.

## Solution
Upgraded `pytest` from 8.2.2 to 9.0.3 in `requirements.txt`, which is the first patched version addressing CVE-2025-71176.

## Test Plan
- [x] All 501 tests pass with pytest 9.0.3
- [x] CI passes on this branch

---
Generated with [Claude Code](https://claude.ai/claude-code)