### PR TITLE
feat: add Sinhala, Tamil, Kannada, Malayalam to Language enum

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+## 0.40.1
+
+- Add Sinhala (`si-lk`), Tamil (`ta-in`), Kannada (`kn-in`), and Malayalam (`ml-in`) to `Language` enum
+
 ## 0.40.0
 
 - Add `script_tags` support to `File` class and evaluation API for tag-based script management

--- a/podonos/common/enum.py
+++ b/podonos/common/enum.py
@@ -194,6 +194,10 @@ class Language(Enum):
     ITALIAN = "it-it"
     POLISH = "pl-pl"
     INDONESIAN = "id-id"
+    SINHALA = "si-lk"
+    TAMIL = "ta-in"
+    KANNADA = "kn-in"
+    MALAYALAM = "ml-in"
     AUDIO = "audio"
 
     @classmethod

--- a/podonos/core/config.py
+++ b/podonos/core/config.py
@@ -215,6 +215,10 @@ class EvalConfig:
             Language.ITALIAN.value,
             Language.POLISH.value,
             Language.INDONESIAN.value,
+            Language.SINHALA.value,
+            Language.TAMIL.value,
+            Language.KANNADA.value,
+            Language.MALAYALAM.value,
             Language.AUDIO.value,
         ]:
             raise ValueError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "podonos"
-version = "0.40.0"
+version = "0.40.1"
 description = "Managed evaluation for audio & speech"
 readme = "README.md"
 license = "MIT"

--- a/tests/common/test_enum.py
+++ b/tests/common/test_enum.py
@@ -25,6 +25,10 @@ class TestLanguageEnum(unittest.TestCase):
         self.assertEqual(Language.JAPANESE.value, "ja-jp")
         self.assertEqual(Language.ITALIAN.value, "it-it")
         self.assertEqual(Language.POLISH.value, "pl-pl")
+        self.assertEqual(Language.SINHALA.value, "si-lk")
+        self.assertEqual(Language.TAMIL.value, "ta-in")
+        self.assertEqual(Language.KANNADA.value, "kn-in")
+        self.assertEqual(Language.MALAYALAM.value, "ml-in")
         self.assertEqual(Language.AUDIO.value, "audio")
 
     def test_language_from_value_en_in(self):
@@ -188,6 +192,16 @@ class TestEvalTypeEnum(unittest.TestCase):
     def test_language_indonesian(self):
         self.assertEqual(Language.INDONESIAN.value, "id-id")
         self.assertEqual(Language.from_value("id-id"), Language.INDONESIAN)
+
+    def test_language_south_asian(self):
+        self.assertEqual(Language.SINHALA.value, "si-lk")
+        self.assertEqual(Language.TAMIL.value, "ta-in")
+        self.assertEqual(Language.KANNADA.value, "kn-in")
+        self.assertEqual(Language.MALAYALAM.value, "ml-in")
+        self.assertEqual(Language.from_value("si-lk"), Language.SINHALA)
+        self.assertEqual(Language.from_value("ta-in"), Language.TAMIL)
+        self.assertEqual(Language.from_value("kn-in"), Language.KANNADA)
+        self.assertEqual(Language.from_value("ml-in"), Language.MALAYALAM)
 
 
 class TestAIEvalTypeEnum(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Add `SINHALA = "si-lk"`, `TAMIL = "ta-in"`, `KANNADA = "kn-in"`, `MALAYALAM = "ml-in"` to `Language` enum
- Add `test_language_south_asian` test covering all 4 new entries
- Bump version 0.40.0 → 0.40.1

## Test plan
- [x] All 25 enum tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)