### PR TITLE
fix(audio): reject corrupted files before upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,6 +176,7 @@ template_ranking.json
 
 # OMC
 .omc/
+.omx/
 
 # Superset worktree metadata
 .superset/

--- a/podonos/core/file.py
+++ b/podonos/core/file.py
@@ -648,16 +648,17 @@ class AudioMeta:
                 f.seek(0)
                 max_abs = 0.0
                 has_audio_data = False
+                found_audible_chunk = False
                 while True:
                     chunk = f.read(frames=65536, dtype="float32")
                     if len(chunk) == 0:
                         break
                     has_audio_data = True
-                    chunk_max = float(abs(chunk).max())
-                    if chunk_max > max_abs:
-                        max_abs = chunk_max
-                    if max_abs >= WARN_SILENT_AMPLITUDE_THRESHOLD:
-                        break
+                    if not found_audible_chunk:
+                        chunk_max = float(abs(chunk).max())
+                        if chunk_max > max_abs:
+                            max_abs = chunk_max
+                        found_audible_chunk = max_abs >= WARN_SILENT_AMPLITUDE_THRESHOLD
 
                 if has_audio_data and max_abs < WARN_SILENT_AMPLITUDE_THRESHOLD:
                     self._is_silent = True

--- a/tests/core/test_audio_validation.py
+++ b/tests/core/test_audio_validation.py
@@ -127,6 +127,47 @@ class TestAudioValidation(unittest.TestCase):
             AudioMeta(os.path.join(self.fixtures_dir, "fake_mp3.wav"))
         self.assertIn("does not match", str(ctx.exception))
 
+    def test_should_raise_for_late_decode_failure_after_non_silent_chunk(self):
+        """Integrity validation should read through the whole file, not stop at first audible chunk.
+
+        A tiny representative corrupt MP3 fixture would be preferable, but creating one
+        portably without FFmpeg or new dependencies is brittle. This fake SoundFile
+        simulates a file that opens and yields initial non-silent audio, then fails
+        while reading a later chunk.
+        """
+
+        class LateFailingSoundFile:
+            frames = 3
+            channels = 1
+            samplerate = 24000
+
+            def __init__(self):
+                self.read_calls = 0
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_value, traceback):
+                return False
+
+            def seek(self, frame):
+                return frame
+
+            def read(self, frames, dtype):
+                self.read_calls += 1
+                if self.read_calls == 1:
+                    return np.array([0.01], dtype=np.float32)
+                raise sf.SoundFileError("late decode failure")
+
+        with patch(
+            "podonos.core.file.sf.SoundFile",
+            return_value=LateFailingSoundFile(),
+        ):
+            with self.assertRaises(InvalidFileError) as ctx:
+                AudioMeta(TESTDATA_SPEECH_CH1_MP3)
+
+        self.assertIn("late decode failure", str(ctx.exception))
+
     def test_should_warn_for_very_short_audio(self):
         """Test that very short audio files trigger a warning."""
         with patch("podonos.core.file.log") as mock_log:

--- a/tests/core/test_evaluator.py
+++ b/tests/core/test_evaluator.py
@@ -13,6 +13,7 @@ from podonos.core.evaluator import Evaluator
 from podonos.core.file import Audio, AudioGroup, File
 from podonos.entity.evaluation import EvaluationEntity
 from podonos.entity.verification import FileVerificationResult, VerifyFilesResponse
+from podonos.errors import InvalidFileError
 from tests.core.test_audio import TESTDATA_SPEECH_TWO_CH1_WAV
 
 
@@ -138,6 +139,20 @@ class TestEvaluator(unittest.TestCase):
             "The 'add_file' is only supported for single file evaluation types:",
             str(context.exception),
         )
+
+    def test_add_file_should_not_queue_upload_when_audio_validation_fails(self):
+        # Given
+        file = File(path=self.test_wav, model_tag="test_model")
+
+        # When/Then
+        with patch(
+            "podonos.core.file.AudioMeta",
+            side_effect=InvalidFileError("late decode failure"),
+        ), patch.object(self.evaluator, "_upload_one_file") as mock_upload:
+            with self.assertRaises(InvalidFileError):
+                self.evaluator.add_file(file)
+
+            mock_upload.assert_not_called()
 
     def test_should_cleanup_successfully(self):
         # Given


### PR DESCRIPTION
## Context
The SDK should reject audio files that cannot be read reliably before they are queued for upload. This keeps validation local to the existing SDK flow without adding new runtime dependencies or changing public APIs.

## Problem
Some corrupted audio files can still look valid from basic metadata or file-type checks, then fail later while being read. The previous validation path could stop reading after detecting audible content, which left late read failures insufficiently covered.

## Solution
- Update `AudioMeta` validation to continue reading audio chunks through EOF while preserving near-silence detection.
- Add a regression test for late read failure after an initial valid chunk.
- Add evaluator coverage to ensure upload queueing is skipped when audio validation fails.
- Ignore generated OMX runtime state in `.gitignore`.

## Test Plan
- [x] `python -m pytest tests/core/test_audio_validation.py tests/core/test_evaluator.py -q`
- [x] Verified no new package dependency was added
- [x] Verified local uncommitted files are not included in this PR

---
Generated with [Podonos Skills](https://github.com/podonos/skills)
