### PR TITLE
feat(language): align locale support with Hindi

### DIFF
--- a/podonos/common/enum.py
+++ b/podonos/common/enum.py
@@ -194,7 +194,7 @@ class Language(Enum):
     ITALIAN = "it-it"
     POLISH = "pl-pl"
     INDONESIAN = "id-id"
-    SINHALA = "si-lk"
+    HINDI = "hi-in"
     TAMIL = "ta-in"
     KANNADA = "kn-in"
     MALAYALAM = "ml-in"

--- a/podonos/core/config.py
+++ b/podonos/core/config.py
@@ -215,7 +215,7 @@ class EvalConfig:
             Language.ITALIAN.value,
             Language.POLISH.value,
             Language.INDONESIAN.value,
-            Language.SINHALA.value,
+            Language.HINDI.value,
             Language.TAMIL.value,
             Language.KANNADA.value,
             Language.MALAYALAM.value,

--- a/tests/common/test_enum.py
+++ b/tests/common/test_enum.py
@@ -25,7 +25,7 @@ class TestLanguageEnum(unittest.TestCase):
         self.assertEqual(Language.JAPANESE.value, "ja-jp")
         self.assertEqual(Language.ITALIAN.value, "it-it")
         self.assertEqual(Language.POLISH.value, "pl-pl")
-        self.assertEqual(Language.SINHALA.value, "si-lk")
+        self.assertEqual(Language.HINDI.value, "hi-in")
         self.assertEqual(Language.TAMIL.value, "ta-in")
         self.assertEqual(Language.KANNADA.value, "kn-in")
         self.assertEqual(Language.MALAYALAM.value, "ml-in")
@@ -194,11 +194,11 @@ class TestEvalTypeEnum(unittest.TestCase):
         self.assertEqual(Language.from_value("id-id"), Language.INDONESIAN)
 
     def test_language_south_asian(self):
-        self.assertEqual(Language.SINHALA.value, "si-lk")
+        self.assertEqual(Language.HINDI.value, "hi-in")
         self.assertEqual(Language.TAMIL.value, "ta-in")
         self.assertEqual(Language.KANNADA.value, "kn-in")
         self.assertEqual(Language.MALAYALAM.value, "ml-in")
-        self.assertEqual(Language.from_value("si-lk"), Language.SINHALA)
+        self.assertEqual(Language.from_value("hi-in"), Language.HINDI)
         self.assertEqual(Language.from_value("ta-in"), Language.TAMIL)
         self.assertEqual(Language.from_value("kn-in"), Language.KANNADA)
         self.assertEqual(Language.from_value("ml-in"), Language.MALAYALAM)


### PR DESCRIPTION
## Context
The SDK language enum is the central locale contract for evaluator creation. Hindi support needs to be represented as `hi-in` instead of the previously listed Sinhala locale.

## Problem
`Language` and `EvalConfig` exposed and accepted Sinhala `si-lk`, so clients could not select Hindi `hi-in` through the typed enum or validation path.

## Solution
- Replaced `Language.SINHALA` with `Language.HINDI = "hi-in"` in `podonos/common/enum.py`.
- Updated `EvalConfig._validate_eval_language()` to accept `Language.HINDI`.
- Updated enum tests to assert `hi-in` parsing and remove Sinhala expectations.

## Test Plan
- [x] `python -m pytest tests/common/test_enum.py tests/core/test_config.py`
- [x] Confirmed the PR diff excludes untracked `mise.toml`.

---
Generated with [Podonos Skills](https://github.com/podonos/skills)
