### PR TITLE
fix(upload): harden resumable upload recovery

### DIFF
--- a/podonos/common/redaction.py
+++ b/podonos/common/redaction.py
@@ -1,0 +1,61 @@
+"""Utilities for redacting secrets from logs, exceptions, and local state."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+_REDACTED = "[REDACTED]"
+
+_SIGNED_URL_RE = re.compile(r"(https?://[^\s?]+)\?[^\s)\]}>]+")
+_SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b("
+    r"x-api-key|api[_-]?key|authorization|bearer|token|access[_-]?token|"
+    r"password|passwd|client[_-]?secret|refresh[_-]?token|id[_-]?token|"
+    r"secret[_-]?key|private[_-]?key|session[_-]?token|oauth[_-]?token|"
+    r"x-amz-signature|x-amz-credential|x-amz-security-token|signature|credential|"
+    r"cloudfront-signature|cloudfront-policy|cloudfront-key-pair-id|"
+    r"cookie|set-cookie"
+    r")\b\s*[:=]\s*[^\s,&)\]}>]+"
+)
+_QUOTED_SECRET_FIELD_RE = re.compile(
+    r"(?i)(['\"](?:"
+    r"x-api-key|api[_-]?key|authorization|bearer|token|access[_-]?token|"
+    r"password|passwd|client[_-]?secret|refresh[_-]?token|id[_-]?token|"
+    r"secret[_-]?key|private[_-]?key|session[_-]?token|oauth[_-]?token|"
+    r"x-amz-signature|x-amz-credential|x-amz-security-token|signature|credential|"
+    r"cloudfront-signature|cloudfront-policy|cloudfront-key-pair-id|"
+    r"cookie|set-cookie"
+    r")['\"]\s*:\s*)['\"][^'\"]+['\"]"
+)
+_BEARER_VALUE_RE = re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._~+\-/]+=*")
+_QUERY_SECRET_RE = re.compile(
+    r"(?i)([?&](?:X-Amz-Signature|X-Amz-Credential|X-Amz-Security-Token|"
+    r"Signature|Credential|token|access_token|refresh_token|id_token|"
+    r"api_key|api-key|password|client_secret|secret_key|private_key|"
+    r"CloudFront-Signature|CloudFront-Policy|CloudFront-Key-Pair-Id)=)[^\s&#)\]}>]+"
+)
+
+
+def redact_secrets(value: Any) -> str:
+    """Return a string with common API keys, bearer tokens, and signed URLs redacted."""
+
+    text = str(value)
+    text = _SIGNED_URL_RE.sub(r"\1?[REDACTED]", text)
+    text = _QUERY_SECRET_RE.sub(lambda match: f"{match.group(1)}{_REDACTED}", text)
+    text = _QUOTED_SECRET_FIELD_RE.sub(
+        lambda match: f"{match.group(1)}'{_REDACTED}'", text
+    )
+    text = _BEARER_VALUE_RE.sub(f"Bearer {_REDACTED}", text)
+    text = _SECRET_ASSIGNMENT_RE.sub(lambda match: f"{match.group(1)}={_REDACTED}", text)
+    return text
+
+
+def mask_secret(value: str, *, visible_prefix: int = 4, visible_suffix: int = 2) -> str:
+    """Mask a single secret for exceptional cases where identity hint is useful."""
+
+    if not value:
+        return _REDACTED
+    if len(value) <= visible_prefix + visible_suffix:
+        return _REDACTED
+    return f"{value[:visible_prefix]}...{value[-visible_suffix:]}"

--- a/podonos/core/api.py
+++ b/podonos/core/api.py
@@ -3,6 +3,7 @@ import requests
 import importlib.metadata
 import time
 import random
+import math
 
 from requests import Response
 from requests.exceptions import RequestException, Timeout, ConnectionError, HTTPError, ConnectTimeout, ReadTimeout
@@ -10,6 +11,7 @@ from typing import Dict, Any, Optional, Callable, Set, Tuple
 from packaging.version import Version
 
 from podonos.common.constant import *
+from podonos.common.redaction import mask_secret, redact_secrets
 from podonos.core.base import *
 from podonos.common.validator import validate_args, Rules
 
@@ -76,7 +78,11 @@ class APIClient:
 
         response = self.patch("api-keys/last-used-time", headers=self._headers, data={})
         if response.text != "true":
-            raise ValueError(TerminalColor.FAIL + f"Invalid API key: {self._api_key}" + TerminalColor.ENDC)
+            raise ValueError(
+                TerminalColor.FAIL
+                + f"Invalid API key: {mask_secret(self._api_key)}"
+                + TerminalColor.ENDC
+            )
         return True
 
     @validate_args(key=Rules.str_non_empty, value=Rules.str_non_empty)
@@ -108,9 +114,71 @@ class APIClient:
         jitter = random.uniform(0.1, 0.3) * delay
         return delay + jitter
 
-    def _execute_with_retry(self, request_func: Callable[[], Response]) -> Response:
+    def _format_retry_context(self, context: Optional[Dict[str, Any]]) -> str:
+        """Format retry context without leaking secrets or signed URLs."""
+        if not context:
+            return ""
+
+        safe_keys = [
+            "method",
+            "endpoint",
+            "evaluation_id",
+            "timeout",
+            "batch_index",
+            "batch_size",
+            "batch_start",
+            "file_count",
+            "total_files",
+            "external_endpoint",
+        ]
+        parts = [
+            f"{key}={redact_secrets(context[key])}"
+            for key in safe_keys
+            if key in context
+        ]
+        return " ".join(parts)
+
+    def _build_retry_context(
+        self,
+        context: Optional[Dict[str, Any]],
+        **reserved: Any,
+    ) -> Dict[str, Any]:
+        """Merge caller context while keeping transport-owned keys authoritative."""
+        request_context = dict(context or {})
+        request_context.update(reserved)
+        return request_context
+
+    @staticmethod
+    def _validate_timeout(timeout: Tuple[float, float]) -> Tuple[float, float]:
+        """Validate public timeout values before they reach requests."""
+
+        if not isinstance(timeout, (tuple, list)) or len(timeout) != 2:
+            raise ValueError("timeout must be a (connect, read) tuple")
+
+        normalized = []
+        for value in timeout:
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise ValueError("timeout values must be positive numbers")
+            if not math.isfinite(float(value)):
+                raise ValueError("timeout values must be finite numbers")
+            if value <= 0:
+                raise ValueError("timeout values must be positive numbers")
+            normalized.append(value)
+
+        return normalized[0], normalized[1]
+
+    def _sanitize_log_message(self, message: str) -> str:
+        """Redact signed URL query strings and common secret-bearing fields."""
+        return redact_secrets(message)
+
+    def _execute_with_retry(
+        self,
+        request_func: Callable[[], Response],
+        context: Optional[Dict[str, Any]] = None,
+    ) -> Response:
         """Execute a request function with retry logic."""
         last_exception = None
+        context_str = self._format_retry_context(context)
 
         for attempt in range(self._max_retries + 1):
             try:
@@ -121,39 +189,60 @@ class APIClient:
                     if attempt < self._max_retries:
                         delay = self._calculate_delay(attempt)
                         log.warning(
-                            f"Request failed with status {response.status_code}, retrying in {delay:.2f}s (attempt {attempt + 1}/{self._max_retries + 1})"
+                            f"Request failed with status {response.status_code} "
+                            f"{context_str}, retrying in {delay:.2f}s "
+                            f"(attempt {attempt + 1}/{self._max_retries + 1})"
                         )
                         time.sleep(delay)
                         continue
                     else:
-                        log.error(f"Request failed after {self._max_retries + 1} attempts with status {response.status_code}")
+                        log.error(
+                            f"Request failed after {self._max_retries + 1} attempts "
+                            f"with status {response.status_code} {context_str}"
+                        )
                         response.raise_for_status()
 
                 return response
 
             except (ConnectionError, Timeout, ConnectTimeout, ReadTimeout) as e:
                 last_exception = e
+                error_message = self._sanitize_log_message(str(e))
                 if attempt < self._max_retries:
                     delay = self._calculate_delay(attempt)
-                    log.warning(f"Network error occurred: {str(e)}, retrying in {delay:.2f}s (attempt {attempt + 1}/{self._max_retries + 1})")
+                    log.warning(
+                        f"Network error occurred {context_str}: {error_message}, "
+                        f"retrying in {delay:.2f}s "
+                        f"(attempt {attempt + 1}/{self._max_retries + 1})"
+                    )
                     time.sleep(delay)
                     continue
                 else:
-                    log.error(f"Network error after {self._max_retries + 1} attempts: {str(e)}")
+                    log.error(
+                        f"Network error after {self._max_retries + 1} attempts "
+                        f"{context_str}: {error_message}"
+                    )
                     raise
             except HTTPError as e:
+                error_message = self._sanitize_log_message(str(e))
                 # For HTTP errors, check if we should retry
                 if self._should_retry(None, e) and attempt < self._max_retries:
                     delay = self._calculate_delay(attempt)
-                    log.warning(f"HTTP error occurred: {str(e)}, retrying in {delay:.2f}s (attempt {attempt + 1}/{self._max_retries + 1})")
+                    log.warning(
+                        f"HTTP error occurred {context_str}: {error_message}, "
+                        f"retrying in {delay:.2f}s "
+                        f"(attempt {attempt + 1}/{self._max_retries + 1})"
+                    )
                     time.sleep(delay)
                     continue
                 else:
-                    log.error(f"HTTP error after {self._max_retries + 1} attempts: {str(e)}")
+                    log.error(
+                        f"HTTP error after {self._max_retries + 1} attempts "
+                        f"{context_str}: {error_message}"
+                    )
                     raise
             except RequestException as e:
                 # For other request exceptions, don't retry
-                log.error(f"Request exception: {str(e)}")
+                log.error(f"Request exception {context_str}: {self._sanitize_log_message(str(e))}")
                 raise
 
         # This should never be reached, but just in case
@@ -167,13 +256,22 @@ class APIClient:
         endpoint: str,
         params: Optional[Dict[str, str]] = None,
         headers: Optional[Dict[str, str]] = None,
+        timeout: Tuple[float, float] = (5, 30),
+        context: Optional[Dict[str, Any]] = None,
     ) -> Response:
+        timeout = self._validate_timeout(timeout)
         request_header = self._headers if headers is None else headers
+        request_context = self._build_retry_context(
+            context,
+            method="GET",
+            endpoint=endpoint,
+            timeout=timeout,
+        )
 
         def make_request():
-            return requests.get(f"{self._api_url}/{endpoint}", headers=request_header, params=params, timeout=(5, 30))
+            return requests.get(f"{self._api_url}/{endpoint}", headers=request_header, params=params, timeout=timeout)
 
-        return self._execute_with_retry(make_request)
+        return self._execute_with_retry(make_request, request_context)
 
     @validate_args(endpoint=Rules.str_non_empty, data=Rules.dict_not_none, headers=Rules.dict_not_none_or_none)
     def post(
@@ -182,13 +280,21 @@ class APIClient:
         data: Dict[str, Any],
         headers: Optional[Dict[str, str]] = None,
         timeout: Tuple[float, float] = (5, 30),
+        context: Optional[Dict[str, Any]] = None,
     ) -> Response:
+        timeout = self._validate_timeout(timeout)
         request_header = self._headers if headers is None else headers
+        request_context = self._build_retry_context(
+            context,
+            method="POST",
+            endpoint=endpoint,
+            timeout=timeout,
+        )
 
         def make_request():
             return requests.post(f"{self._api_url}/{endpoint}", headers=request_header, json=data, timeout=timeout)
 
-        return self._execute_with_retry(make_request)
+        return self._execute_with_retry(make_request, request_context)
 
     @validate_args(endpoint=Rules.str_non_empty, data=Rules.dict_not_none, headers=Rules.dict_not_none_or_none)
     def put(
@@ -196,13 +302,22 @@ class APIClient:
         endpoint: str,
         data: Dict[str, Any],
         headers: Optional[Dict[str, str]] = None,
+        timeout: Tuple[float, float] = (5, 30),
+        context: Optional[Dict[str, Any]] = None,
     ) -> Response:
+        timeout = self._validate_timeout(timeout)
         request_header = self._headers if headers is None else headers
+        request_context = self._build_retry_context(
+            context,
+            method="PUT",
+            endpoint=endpoint,
+            timeout=timeout,
+        )
 
         def make_request():
-            return requests.put(f"{self._api_url}/{endpoint}", headers=request_header, json=data, timeout=(5, 30))
+            return requests.put(f"{self._api_url}/{endpoint}", headers=request_header, json=data, timeout=timeout)
 
-        return self._execute_with_retry(make_request)
+        return self._execute_with_retry(make_request, request_context)
 
     @validate_args(endpoint=Rules.str_non_empty, data=Rules.dict_not_none, headers=Rules.dict_not_none_or_none)
     def patch(
@@ -210,22 +325,44 @@ class APIClient:
         endpoint: str,
         data: Dict[str, Any],
         headers: Optional[Dict[str, str]] = None,
+        timeout: Tuple[float, float] = (5, 30),
+        context: Optional[Dict[str, Any]] = None,
     ) -> Response:
+        timeout = self._validate_timeout(timeout)
         request_header = self._headers if headers is None else headers
+        request_context = self._build_retry_context(
+            context,
+            method="PATCH",
+            endpoint=endpoint,
+            timeout=timeout,
+        )
 
         def make_request():
-            return requests.patch(f"{self._api_url}/{endpoint}", headers=request_header, json=data, timeout=(5, 30))
+            return requests.patch(f"{self._api_url}/{endpoint}", headers=request_header, json=data, timeout=timeout)
 
-        return self._execute_with_retry(make_request)
+        return self._execute_with_retry(make_request, request_context)
 
     @validate_args(endpoint=Rules.str_non_empty, headers=Rules.dict_not_none_or_none)
-    def delete(self, endpoint: str, headers: Optional[Dict[str, str]] = None) -> Response:
+    def delete(
+        self,
+        endpoint: str,
+        headers: Optional[Dict[str, str]] = None,
+        timeout: Tuple[float, float] = (5, 30),
+        context: Optional[Dict[str, Any]] = None,
+    ) -> Response:
+        timeout = self._validate_timeout(timeout)
         request_header = self._headers if headers is None else headers
+        request_context = self._build_retry_context(
+            context,
+            method="DELETE",
+            endpoint=endpoint,
+            timeout=timeout,
+        )
 
         def make_request():
-            return requests.delete(f"{self._api_url}/{endpoint}", headers=request_header, timeout=(5, 30))
+            return requests.delete(f"{self._api_url}/{endpoint}", headers=request_header, timeout=timeout)
 
-        return self._execute_with_retry(make_request)
+        return self._execute_with_retry(make_request, request_context)
 
     @validate_args(
         url=Rules.str_non_empty, params=Rules.dict_not_none_or_none, headers=Rules.dict_not_none_or_none, cookies=Rules.dict_not_none_or_none
@@ -236,14 +373,31 @@ class APIClient:
         params: Optional[Dict[str, str]] = None,
         headers: Optional[Dict[str, str]] = None,
         cookies: Optional[Dict[str, str]] = None,
+        timeout: Tuple[float, float] = (10, 60),
+        context: Optional[Dict[str, Any]] = None,
+        allow_redirects: bool = True,
     ) -> Response:
         """Make a GET request to an external URL with retry logic."""
+        timeout = self._validate_timeout(timeout)
         request_header = headers or {}
+        request_context = self._build_retry_context(
+            context,
+            method="GET",
+            external_endpoint="external_get",
+            timeout=timeout,
+        )
 
         def make_request():
-            return requests.get(url, headers=request_header, params=params, cookies=cookies, timeout=(10, 60))
+            return requests.get(
+                url,
+                headers=request_header,
+                params=params,
+                cookies=cookies,
+                timeout=timeout,
+                allow_redirects=allow_redirects,
+            )
 
-        return self._execute_with_retry(make_request)
+        return self._execute_with_retry(make_request, request_context)
 
     @validate_args(url=Rules.str_non_empty, json_data=Rules.dict_not_none_or_none, headers=Rules.dict_not_none_or_none)
     def external_put(
@@ -252,17 +406,35 @@ class APIClient:
         data: Optional[Any] = None,
         json_data: Optional[Dict[str, Any]] = None,
         headers: Optional[Dict[str, str]] = None,
+        timeout: Tuple[float, float] = (10, 120),
+        context: Optional[Dict[str, Any]] = None,
     ) -> Response:
         """Make a PUT request to an external URL with retry logic."""
+        timeout = self._validate_timeout(timeout)
         request_header = headers or {}
+        request_context = self._build_retry_context(
+            context,
+            method="PUT",
+            external_endpoint="presigned_put",
+            timeout=timeout,
+        )
+
+        data_initial_position: Optional[int] = None
+        if data is not None and hasattr(data, "tell") and hasattr(data, "seek"):
+            try:
+                data_initial_position = data.tell()
+            except Exception:
+                data_initial_position = None
 
         def make_request():
             if json_data is not None:
-                return requests.put(url, headers=request_header, json=json_data, timeout=(10, 120))
+                return requests.put(url, headers=request_header, json=json_data, timeout=timeout)
             else:
-                return requests.put(url, headers=request_header, data=data, timeout=(10, 120))
+                if data_initial_position is not None:
+                    data.seek(data_initial_position)
+                return requests.put(url, headers=request_header, data=data, timeout=timeout)
 
-        return self._execute_with_retry(make_request)
+        return self._execute_with_retry(make_request, request_context)
 
     @validate_args(url=Rules.str_non_empty, json_data=Rules.dict_not_none_or_none, headers=Rules.dict_not_none_or_none)
     def external_post(
@@ -271,17 +443,26 @@ class APIClient:
         data: Optional[Any] = None,
         json_data: Optional[Dict[str, Any]] = None,
         headers: Optional[Dict[str, str]] = None,
+        timeout: Tuple[float, float] = (10, 60),
+        context: Optional[Dict[str, Any]] = None,
     ) -> Response:
         """Make a POST request to an external URL with retry logic."""
+        timeout = self._validate_timeout(timeout)
         request_header = headers or {}
+        request_context = self._build_retry_context(
+            context,
+            method="POST",
+            external_endpoint="external_post",
+            timeout=timeout,
+        )
 
         def make_request():
             if json_data is not None:
-                return requests.post(url, headers=request_header, json=json_data, timeout=(10, 60))
+                return requests.post(url, headers=request_header, json=json_data, timeout=timeout)
             else:
-                return requests.post(url, headers=request_header, data=data, timeout=(10, 60))
+                return requests.post(url, headers=request_header, data=data, timeout=timeout)
 
-        return self._execute_with_retry(make_request)
+        return self._execute_with_retry(make_request, request_context)
 
     def _check_minimum_version(self) -> bool:
         response = self.get("version/sdk")

--- a/podonos/core/client.py
+++ b/podonos/core/client.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 from podonos.common.enum import CustomType
 from podonos.common.validator import Rules, validate_args, validate_custom_type
@@ -61,6 +61,11 @@ class Client:
         auto_start=Rules.bool_not_none,
         max_upload_workers=Rules.positive_not_none,
         verify_batch_size=Rules.positive_not_none,
+        api_timeout=Rules.make_type_rule((tuple, list)),
+        verify_timeout=Rules.make_type_rule((tuple, list)),
+        upload_timeout=Rules.make_type_rule((tuple, list)),
+        resume_upload=Rules.bool_not_none,
+        upload_state_path=Rules.str_not_none_or_none,
     )
     def create_evaluator(
         self,
@@ -76,6 +81,11 @@ class Client:
         auto_start: bool = EvalConfigDefault.AUTO_START,
         max_upload_workers: int = EvalConfigDefault.MAX_UPLOAD_WORKERS,
         verify_batch_size: int = EvalConfigDefault.VERIFY_BATCH_SIZE,
+        api_timeout: Tuple[float, float] = EvalConfigDefault.API_TIMEOUT,
+        verify_timeout: Tuple[float, float] = EvalConfigDefault.VERIFY_TIMEOUT,
+        upload_timeout: Tuple[float, float] = EvalConfigDefault.UPLOAD_TIMEOUT,
+        resume_upload: bool = EvalConfigDefault.RESUME_UPLOAD,
+        upload_state_path: Optional[str] = EvalConfigDefault.UPLOAD_STATE_PATH,
     ) -> Evaluator:
         """Creates a new evaluator with a unique evaluation session ID.
         For the language code, see https://www.podonos.com/docs/reference#param-lan
@@ -93,7 +103,12 @@ class Client:
             use_loudness_normalization: Enable loudness normalization for evaluation.
             auto_start: The evaluation start automatically if True. Otherwise, manually start in the workspace.
             max_upload_workers: The maximum number of upload workers. Must be a positive integer. Default: 20
-            verify_batch_size: The batch size for file verification API calls. Must be 1-1000. Default: 500
+            verify_batch_size: The batch size for file verification API calls. Must be 1-1000. Default: 100
+            api_timeout: Default API timeout tuple. Default: (5, 30)
+            verify_timeout: File verification timeout tuple. Default: (5, 120)
+            upload_timeout: Direct upload timeout tuple. Default: (10, 300)
+            resume_upload: Enable SDK-local upload ledger/resume. Default: False
+            upload_state_path: Optional SQLite ledger path when resume_upload is enabled.
 
         Returns:
             Evaluator instance.
@@ -105,18 +120,89 @@ class Client:
         if not self._initialized:
             raise ValueError("This function is called before initialization.")
         return self._human_evaluation.create(
-            name,
-            desc,
-            type,
-            lan,
-            granularity,
-            num_eval,
-            due_hours,
-            use_annotation,
-            use_loudness_normalization,
-            auto_start,
-            max_upload_workers,
-            verify_batch_size,
+            name=name,
+            desc=desc,
+            type=type,
+            lan=lan,
+            granularity=granularity,
+            num_eval=num_eval,
+            due_hours=due_hours,
+            use_annotation=use_annotation,
+            use_loudness_normalization=use_loudness_normalization,
+            auto_start=auto_start,
+            max_upload_workers=max_upload_workers,
+            verify_batch_size=verify_batch_size,
+            api_timeout=api_timeout,
+            verify_timeout=verify_timeout,
+            upload_timeout=upload_timeout,
+            resume_upload=resume_upload,
+            upload_state_path=upload_state_path,
+        )
+
+    @validate_args(
+        evaluation_id=Rules.uuid_not_none,
+        upload_state_path=Rules.str_non_empty,
+        name=Rules.str_not_none_or_none,
+        desc=Rules.str_not_none_or_none,
+        type=Rules.str_non_empty,
+        lan=Rules.str_non_empty,
+        granularity=Rules.float_not_none,
+        num_eval=Rules.positive_not_none,
+        due_hours=Rules.positive_not_none,
+        use_annotation=Rules.bool_not_none,
+        use_loudness_normalization=Rules.bool_not_none,
+        auto_start=Rules.bool_not_none,
+        max_upload_workers=Rules.positive_not_none,
+        verify_batch_size=Rules.positive_not_none,
+        api_timeout=Rules.make_type_rule((tuple, list)),
+        verify_timeout=Rules.make_type_rule((tuple, list)),
+        upload_timeout=Rules.make_type_rule((tuple, list)),
+    )
+    def resume_evaluator(
+        self,
+        evaluation_id: str,
+        upload_state_path: str,
+        name: Optional[str] = None,
+        desc: Optional[str] = None,
+        type: str = EvalConfigDefault.TYPE.value,
+        lan: str = EvalConfigDefault.LAN.value,
+        granularity: float = EvalConfigDefault.GRANULARITY,
+        num_eval: int = EvalConfigDefault.NUM_EVAL,
+        due_hours: int = EvalConfigDefault.DUE_HOURS,
+        use_annotation: bool = EvalConfigDefault.USE_ANNOTATION,
+        use_loudness_normalization: bool = EvalConfigDefault.USE_LOUDNESS_NORMALIZATION,
+        auto_start: bool = EvalConfigDefault.AUTO_START,
+        max_upload_workers: int = EvalConfigDefault.MAX_UPLOAD_WORKERS,
+        verify_batch_size: int = EvalConfigDefault.VERIFY_BATCH_SIZE,
+        api_timeout: Tuple[float, float] = EvalConfigDefault.API_TIMEOUT,
+        verify_timeout: Tuple[float, float] = EvalConfigDefault.VERIFY_TIMEOUT,
+        upload_timeout: Tuple[float, float] = EvalConfigDefault.UPLOAD_TIMEOUT,
+    ) -> Evaluator:
+        """Resume uploads for an existing evaluation using an SDK upload ledger.
+
+        The caller must add files again in the same order as the interrupted run
+        so the ledger can recover each file's remote object identity.
+        """
+        if not self._initialized:
+            raise ValueError("This function is called before initialization.")
+        return self._human_evaluation.resume(
+            evaluation_id=evaluation_id,
+            upload_state_path=upload_state_path,
+            name=name,
+            desc=desc,
+            type=type,
+            lan=lan,
+            granularity=granularity,
+            num_eval=num_eval,
+            due_hours=due_hours,
+            use_annotation=use_annotation,
+            use_loudness_normalization=use_loudness_normalization,
+            auto_start=auto_start,
+            max_upload_workers=max_upload_workers,
+            verify_batch_size=verify_batch_size,
+            api_timeout=api_timeout,
+            verify_timeout=verify_timeout,
+            upload_timeout=upload_timeout,
         )
 
     @validate_args(
@@ -129,6 +215,11 @@ class Client:
         use_annotation=Rules.bool_not_none,
         use_loudness_normalization=Rules.bool_not_none,
         verify_batch_size=Rules.positive_not_none,
+        api_timeout=Rules.make_type_rule((tuple, list)),
+        verify_timeout=Rules.make_type_rule((tuple, list)),
+        upload_timeout=Rules.make_type_rule((tuple, list)),
+        resume_upload=Rules.bool_not_none,
+        upload_state_path=Rules.str_not_none_or_none,
     )
     def create_evaluator_from_template(
         self,
@@ -141,6 +232,11 @@ class Client:
         use_annotation: bool = EvalConfigDefault.USE_ANNOTATION,
         use_loudness_normalization: bool = EvalConfigDefault.USE_LOUDNESS_NORMALIZATION,
         verify_batch_size: int = EvalConfigDefault.VERIFY_BATCH_SIZE,
+        api_timeout: Tuple[float, float] = EvalConfigDefault.API_TIMEOUT,
+        verify_timeout: Tuple[float, float] = EvalConfigDefault.VERIFY_TIMEOUT,
+        upload_timeout: Tuple[float, float] = EvalConfigDefault.UPLOAD_TIMEOUT,
+        resume_upload: bool = EvalConfigDefault.RESUME_UPLOAD,
+        upload_state_path: Optional[str] = EvalConfigDefault.UPLOAD_STATE_PATH,
     ) -> Evaluator:
         """
         Creates a new evaluator using a predefined template.
@@ -154,7 +250,12 @@ class Client:
             max_upload_workers: The maximum number of upload workers. Must be a positive integer. Default: 20
             use_annotation: Enable detailed annotation on script for detailed comments. Default: False
             use_loudness_normalization: Enable loudness normalization for evaluation. Default: True
-            verify_batch_size: The batch size for file verification API calls. Must be 1-1000. Default: 500
+            verify_batch_size: The batch size for file verification API calls. Must be 1-1000. Default: 100
+            api_timeout: Default API timeout tuple. Default: (5, 30)
+            verify_timeout: File verification timeout tuple. Default: (5, 120)
+            upload_timeout: Direct upload timeout tuple. Default: (10, 300)
+            resume_upload: Enable SDK-local upload ledger/resume. Default: False
+            upload_state_path: Optional SQLite ledger path when resume_upload is enabled.
 
         Returns:
             Evaluator instance.
@@ -166,15 +267,20 @@ class Client:
             raise ValueError("This function is called before initialization.")
 
         return self._human_evaluation.create_from_template(
-            name,
-            template_id,
-            num_eval,
-            desc,
-            use_annotation,
-            use_loudness_normalization,
-            auto_start,
-            max_upload_workers,
-            verify_batch_size,
+            name=name,
+            template_id=template_id,
+            num_eval=num_eval,
+            desc=desc,
+            use_annotation=use_annotation,
+            use_loudness_normalization=use_loudness_normalization,
+            auto_start=auto_start,
+            max_upload_workers=max_upload_workers,
+            verify_batch_size=verify_batch_size,
+            api_timeout=api_timeout,
+            verify_timeout=verify_timeout,
+            upload_timeout=upload_timeout,
+            resume_upload=resume_upload,
+            upload_state_path=upload_state_path,
         )
 
     @validate_args(
@@ -190,6 +296,11 @@ class Client:
         auto_start=Rules.bool_not_none,
         max_upload_workers=Rules.positive_not_none,
         verify_batch_size=Rules.positive_not_none,
+        api_timeout=Rules.make_type_rule((tuple, list)),
+        verify_timeout=Rules.make_type_rule((tuple, list)),
+        upload_timeout=Rules.make_type_rule((tuple, list)),
+        resume_upload=Rules.bool_not_none,
+        upload_state_path=Rules.str_not_none_or_none,
     )
     def create_evaluator_from_template_json(
         self,
@@ -205,6 +316,11 @@ class Client:
         auto_start: bool = EvalConfigDefault.AUTO_START,
         max_upload_workers: int = EvalConfigDefault.MAX_UPLOAD_WORKERS,
         verify_batch_size: int = EvalConfigDefault.VERIFY_BATCH_SIZE,
+        api_timeout: Tuple[float, float] = EvalConfigDefault.API_TIMEOUT,
+        verify_timeout: Tuple[float, float] = EvalConfigDefault.VERIFY_TIMEOUT,
+        upload_timeout: Tuple[float, float] = EvalConfigDefault.UPLOAD_TIMEOUT,
+        resume_upload: bool = EvalConfigDefault.RESUME_UPLOAD,
+        upload_state_path: Optional[str] = EvalConfigDefault.UPLOAD_STATE_PATH,
     ) -> Evaluator:
         """Creates a new evaluator using a template JSON.
 
@@ -220,7 +336,12 @@ class Client:
             use_loudness_normalization: Enable loudness normalization for evaluation. Default: False
             auto_start: The evaluation start automatically if True. Otherwise, manually start in the workspace.
             max_upload_workers: The maximum number of upload workers. Must be a positive integer. Default: 20
-            verify_batch_size: The batch size for file verification API calls. Must be 1-1000. Default: 500
+            verify_batch_size: The batch size for file verification API calls. Must be 1-1000. Default: 100
+            api_timeout: Default API timeout tuple. Default: (5, 30)
+            verify_timeout: File verification timeout tuple. Default: (5, 120)
+            upload_timeout: Direct upload timeout tuple. Default: (10, 300)
+            resume_upload: Enable SDK-local upload ledger/resume. Default: False
+            upload_state_path: Optional SQLite ledger path when resume_upload is enabled.
 
         Returns:
             Evaluator instance.
@@ -247,6 +368,11 @@ class Client:
             auto_start=auto_start,
             max_upload_workers=max_upload_workers,
             verify_batch_size=verify_batch_size,
+            api_timeout=api_timeout,
+            verify_timeout=verify_timeout,
+            upload_timeout=upload_timeout,
+            resume_upload=resume_upload,
+            upload_state_path=upload_state_path,
         )
 
     @validate_args(

--- a/podonos/core/config.py
+++ b/podonos/core/config.py
@@ -1,8 +1,12 @@
+import os
+import uuid
+import math
 from datetime import datetime, timedelta
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 from podonos.common.constant import PODONOS_CONTACT_EMAIL
 from podonos.common.enum import AIEvalType, EvalType, Language
+from podonos.common.redaction import mask_secret
 from podonos.common.validator import Rules, validate_args
 from podonos.core.base import *
 
@@ -19,7 +23,12 @@ class EvalConfigDefault:
     GRANULARITY = 1.0
     BATCH_SIZE = 1
     MAX_UPLOAD_WORKERS = 20
-    VERIFY_BATCH_SIZE = 500
+    VERIFY_BATCH_SIZE = 100
+    API_TIMEOUT = (5, 30)
+    VERIFY_TIMEOUT = (5, 120)
+    UPLOAD_TIMEOUT = (10, 300)
+    RESUME_UPLOAD = False
+    UPLOAD_STATE_PATH = None
 
 
 class EvalConfig:
@@ -44,6 +53,12 @@ class EvalConfig:
     _skip_default_questions: bool = False
     _max_upload_workers: int = EvalConfigDefault.MAX_UPLOAD_WORKERS
     _verify_batch_size: int = EvalConfigDefault.VERIFY_BATCH_SIZE
+    _api_timeout: Tuple[float, float] = EvalConfigDefault.API_TIMEOUT
+    _verify_timeout: Tuple[float, float] = EvalConfigDefault.VERIFY_TIMEOUT
+    _upload_timeout: Tuple[float, float] = EvalConfigDefault.UPLOAD_TIMEOUT
+    _resume_upload: bool = EvalConfigDefault.RESUME_UPLOAD
+    _upload_state_path: Optional[str] = EvalConfigDefault.UPLOAD_STATE_PATH
+    _resume_evaluation_id: Optional[str] = None
 
     def __init__(
         self,
@@ -61,6 +76,12 @@ class EvalConfig:
         template_id: Optional[str] = None,
         max_upload_workers: int = EvalConfigDefault.MAX_UPLOAD_WORKERS,
         verify_batch_size: int = EvalConfigDefault.VERIFY_BATCH_SIZE,
+        api_timeout: Tuple[float, float] = EvalConfigDefault.API_TIMEOUT,
+        verify_timeout: Tuple[float, float] = EvalConfigDefault.VERIFY_TIMEOUT,
+        upload_timeout: Tuple[float, float] = EvalConfigDefault.UPLOAD_TIMEOUT,
+        resume_upload: bool = EvalConfigDefault.RESUME_UPLOAD,
+        upload_state_path: Optional[str] = EvalConfigDefault.UPLOAD_STATE_PATH,
+        resume_evaluation_id: Optional[str] = None,
         skip_default_questions: bool = False,
     ) -> None:
         self._eval_name = self._valudate_eval_name(name)
@@ -83,6 +104,14 @@ class EvalConfig:
         self._eval_template_id = template_id
         self._max_upload_workers = max_upload_workers
         self._verify_batch_size = self._validate_verify_batch_size(verify_batch_size)
+        self._api_timeout = self._validate_timeout(api_timeout, "api_timeout")
+        self._verify_timeout = self._validate_timeout(verify_timeout, "verify_timeout")
+        self._upload_timeout = self._validate_timeout(upload_timeout, "upload_timeout")
+        self._resume_upload = self._validate_resume_upload(resume_upload)
+        self._upload_state_path = self._validate_upload_state_path(upload_state_path)
+        self._resume_evaluation_id = self._validate_resume_evaluation_id(
+            resume_evaluation_id
+        )
         self._skip_default_questions = skip_default_questions
         self.log_eval_config()
 
@@ -105,6 +134,22 @@ class EvalConfig:
         log.debug(f"Evaluation Template ID: {self._eval_template_id}")
         log.debug(f"Max upload workers: {self._max_upload_workers}")
         log.debug(f"Verify batch size: {self._verify_batch_size}")
+        log.debug(f"API timeout: {self._api_timeout}")
+        log.debug(f"Verify timeout: {self._verify_timeout}")
+        log.debug(f"Upload timeout: {self._upload_timeout}")
+        log.debug(f"Resume upload: {self._resume_upload}")
+        upload_state_display = (
+            os.path.basename(self._upload_state_path)
+            if self._upload_state_path
+            else None
+        )
+        resume_id_display = (
+            mask_secret(self._resume_evaluation_id)
+            if self._resume_evaluation_id
+            else None
+        )
+        log.debug(f"Upload state path basename: {upload_state_display}")
+        log.debug(f"Resume evaluation id: {resume_id_display}")
         log.debug(f"Skip default questions: {self._skip_default_questions}")
 
     @property
@@ -150,6 +195,41 @@ class EvalConfig:
     @property
     def verify_batch_size(self) -> int:
         return self._verify_batch_size
+
+    @property
+    def api_timeout(self) -> Tuple[float, float]:
+        return self._api_timeout
+
+    @property
+    def verify_timeout(self) -> Tuple[float, float]:
+        return self._verify_timeout
+
+    @property
+    def upload_timeout(self) -> Tuple[float, float]:
+        return self._upload_timeout
+
+    @property
+    def resume_upload(self) -> bool:
+        return self._resume_upload
+
+    @property
+    def upload_state_path(self) -> Optional[str]:
+        return self._upload_state_path
+
+    @property
+    def resume_evaluation_id(self) -> Optional[str]:
+        return self._resume_evaluation_id
+
+    def resolve_upload_state_path(self) -> str:
+        """Return the local ledger path when opt-in resume_upload is enabled.
+
+        The default path is deterministic and SDK-local. Calling this method does
+        not create a file; the SQLite ledger is created only if integration code
+        instantiates UploadLedger while resume_upload is enabled.
+        """
+        if self._upload_state_path:
+            return self._upload_state_path
+        return os.path.join(os.getcwd(), ".podonos_upload_state.sqlite")
 
     @property
     def eval_batch_size(self) -> int:
@@ -302,6 +382,100 @@ class EvalConfig:
         if verify_batch_size > 1000:
             raise ValueError('"verify_batch_size" must be <= 1000.')
         return verify_batch_size
+
+    def _validate_timeout(
+        self, timeout: Tuple[float, float], name: str
+    ) -> Tuple[float, float]:
+        if not isinstance(timeout, (tuple, list)) or len(timeout) != 2:
+            raise ValueError(f'"{name}" must be a 2-item tuple/list: (connect_timeout, read_timeout).')
+
+        connect_timeout, read_timeout = timeout
+        if isinstance(connect_timeout, bool) or isinstance(read_timeout, bool):
+            raise ValueError(f'"{name}" values must be positive numbers.')
+        if not isinstance(connect_timeout, (int, float)) or not isinstance(
+            read_timeout, (int, float)
+        ):
+            raise ValueError(f'"{name}" values must be numbers.')
+        if not math.isfinite(float(connect_timeout)) or not math.isfinite(
+            float(read_timeout)
+        ):
+            raise ValueError(f'"{name}" values must be finite.')
+        if connect_timeout <= 0 or read_timeout <= 0:
+            raise ValueError(f'"{name}" values must be positive.')
+        if connect_timeout > read_timeout:
+            raise ValueError(f'"{name}" connect timeout must be <= read timeout.')
+
+        return (connect_timeout, read_timeout)
+
+    def restore_resume_session_config(self, session_config: Dict[str, Any]) -> None:
+        """Restore original session.json fields from a trusted upload ledger contract."""
+
+        if not isinstance(session_config, dict) or not session_config:
+            raise ValueError("session_config must be a non-empty dictionary")
+
+        self._eval_name = str(session_config.get("eval_name", self._eval_name))
+        self._eval_description = session_config.get(
+            "eval_description", self._eval_description
+        )
+        self._eval_num = int(session_config.get("eval_num", self._eval_num))
+        self._eval_expected_due = str(
+            session_config.get("eval_expected_due", self._eval_expected_due)
+        )
+        self._eval_creation_timestamp = str(
+            session_config.get(
+                "eval_creation_timestamp", self._eval_creation_timestamp
+            )
+        )
+        self._eval_use_annotation = bool(
+            session_config.get("eval_use_annotation", self._eval_use_annotation)
+        )
+        self._eval_auto_start = bool(
+            session_config.get("eval_auto_start", self._eval_auto_start)
+        )
+        self._eval_template_id = session_config.get(
+            "eval_template_id", self._eval_template_id
+        )
+        self._eval_use_loudness_normalization = bool(
+            session_config.get(
+                "use_loudness_normalization",
+                self._eval_use_loudness_normalization,
+            )
+        )
+        self._max_upload_workers = int(
+            session_config.get("max_upload_workers", self._max_upload_workers)
+        )
+        self._verify_batch_size = self._validate_verify_batch_size(
+            int(session_config.get("verify_batch_size", self._verify_batch_size))
+        )
+
+    def _validate_resume_upload(self, resume_upload: bool) -> bool:
+        if not isinstance(resume_upload, bool):  # type: ignore
+            raise ValueError('"resume_upload" must be a boolean.')
+        return resume_upload
+
+    def _validate_upload_state_path(
+        self, upload_state_path: Optional[str]
+    ) -> Optional[str]:
+        if upload_state_path is None:
+            return None
+        if not isinstance(upload_state_path, str) or not upload_state_path.strip():
+            raise ValueError('"upload_state_path" must be a non-empty string or None.')
+        return upload_state_path
+
+    def _validate_resume_evaluation_id(
+        self, resume_evaluation_id: Optional[str]
+    ) -> Optional[str]:
+        if resume_evaluation_id is None:
+            return None
+        if not isinstance(resume_evaluation_id, str) or not resume_evaluation_id.strip():
+            raise ValueError(
+                '"resume_evaluation_id" must be a non-empty string or None.'
+            )
+        try:
+            uuid.UUID(resume_evaluation_id)
+        except ValueError as exc:
+            raise ValueError('"resume_evaluation_id" must be a valid UUID.') from exc
+        return resume_evaluation_id
 
     def to_dict(self) -> Dict[str, Any]:
         return {

--- a/podonos/core/evaluator.py
+++ b/podonos/core/evaluator.py
@@ -689,6 +689,7 @@ class Evaluator:
         for i in range(0, len(audios), 500):
             batch = audios[i : i + 500]
             batch_to_register: List[Audio] = []
+            ledger_batch_to_mark_registered: List[Audio] = []
             for audio in batch:
                 row = self._get_ledger_row(audio)
                 if row is None:
@@ -699,6 +700,7 @@ class Evaluator:
                         self.get_evaluation_id(), audio.remote_object_name
                     )
                     batch_to_register.append(audio)
+                    ledger_batch_to_mark_registered.append(audio)
 
             if not batch_to_register:
                 continue
@@ -716,7 +718,7 @@ class Evaluator:
                     },
                 )
             except Exception as exc:
-                for audio in batch_to_register:
+                for audio in ledger_batch_to_mark_registered:
                     try:
                         self._upload_ledger.mark_metadata_registration_retry_needed(
                             self.get_evaluation_id(),
@@ -730,7 +732,7 @@ class Evaluator:
                             f"{audio.remote_object_name}: {redact_secrets(ledger_exc)}"
                         )
                 raise
-            for audio in batch_to_register:
+            for audio in ledger_batch_to_mark_registered:
                 self._upload_ledger.mark_metadata_registered(
                     self.get_evaluation_id(), audio.remote_object_name
                 )

--- a/podonos/core/evaluator.py
+++ b/podonos/core/evaluator.py
@@ -1,11 +1,22 @@
-from typing import Any, Dict, List, Optional, cast
+import hashlib
+import json
+import os
+from typing import Any, Dict, List, Optional
 
 from podonos.common.enum import EvalType
+from podonos.common.redaction import redact_secrets
+from podonos.common.util import calculate_file_md5_base64
 from podonos.common.validator import Rules, validate_args
 from podonos.core.api import APIClient
 from podonos.core.base import log
 from podonos.core.config import EvalConfig
 from podonos.core.file import Audio, AudioGroup, File, FileTransformer, FileValidator
+from podonos.core.upload_ledger import (
+    UploadLedger,
+    UploadLedgerRow,
+    build_upload_manifest_hash,
+    build_upload_manifest_key,
+)
 from podonos.core.upload_manager import UploadManager
 from podonos.entity.evaluation import EvaluationEntity
 from podonos.entity.verification import FileVerificationResult, VerifyFilesResponse
@@ -13,7 +24,6 @@ from podonos.errors.error import FileVerificationFailure, UploadRetryExhaustedEr
 from podonos.service.evaluation_service import EvaluationService
 
 MAX_UPLOAD_RETRIES = 3
-DEFAULT_VERIFY_BATCH_SIZE = 500  # Default batch size, can be overridden via EvalConfig
 
 
 class Evaluator:
@@ -30,7 +40,9 @@ class Evaluator:
     _upload_manager: Optional[UploadManager] = (
         None  # Upload manager. Lazy initialization when used for saving resources.
     )
+    _upload_ledger: Optional[UploadLedger] = None
     _ordered_file_groups: List[AudioGroup]  # ordered evaluation files groups
+    _next_file_index: int = 0
 
     def __init__(
         self,
@@ -96,12 +108,79 @@ class Evaluator:
         self._api_client = api_client
         self._eval_config = eval_config
         self._evaluation_service = EvaluationService(api_client)
+        self._upload_ledger = self._initialize_upload_ledger(eval_config)
         self._evaluation = self._set_evaluation(eval_config)
         self._file_transformer = FileTransformer(eval_config)
         self._file_validator = FileValidator(eval_config)
         self._supported_eval_types = supported_eval_types
         self._ordered_file_groups = []
         self._upload_manager = None
+        self._bind_upload_ledger_contract(eval_config)
+        self._next_file_index = 0
+
+    def _initialize_upload_ledger(
+        self, eval_config: EvalConfig
+    ) -> Optional[UploadLedger]:
+        if not eval_config.resume_upload:
+            return None
+        return UploadLedger(eval_config.resolve_upload_state_path())
+
+    def _session_config_contract(self, eval_config: EvalConfig) -> Dict[str, Any]:
+        session_config = dict(eval_config.to_dict())
+        session_config.pop("eval_id", None)
+        return session_config
+
+    def _build_upload_ledger_contract(self, eval_config: EvalConfig) -> Dict[str, Any]:
+        return {
+            "evaluation_id": self.get_evaluation_id(),
+            "eval_type": eval_config.eval_type.value,
+            "eval_language": eval_config.eval_language.value,
+            "eval_batch_size": eval_config.eval_batch_size,
+            "eval_template_id": eval_config.eval_template_id,
+            "use_annotation": eval_config.eval_use_annotation,
+            "use_loudness_normalization": eval_config.use_loudness_normalization,
+            "session_config": self._session_config_contract(eval_config),
+        }
+
+    def _bind_upload_ledger_contract(self, eval_config: EvalConfig) -> None:
+        if self._upload_ledger is None:
+            return
+
+        existing = self._upload_ledger.get_evaluation_contract(self.get_evaluation_id())
+        if existing is None:
+            if eval_config.resume_evaluation_id:
+                raise ValueError(
+                    "Upload ledger is missing the original evaluation contract; "
+                    "cannot safely resume this evaluation."
+                )
+            contract = self._build_upload_ledger_contract(eval_config)
+            self._upload_ledger.set_evaluation_contract(
+                self.get_evaluation_id(), contract
+            )
+            return
+
+        contract = self._build_upload_ledger_contract(eval_config)
+        mismatches = {
+            key: (existing.get(key), value)
+            for key, value in contract.items()
+            if key != "evaluation_id" and existing.get(key) != value
+        }
+        if mismatches:
+            details = ", ".join(sorted(mismatches))
+            raise ValueError(
+                "Upload ledger evaluation contract does not match the current "
+                f"resume configuration (mismatched keys: {details}). "
+                "Start a fresh evaluation or resume with the original SDK "
+                "configuration."
+            )
+
+    def _store_upload_ledger_contract(self) -> None:
+        if self._upload_ledger is None:
+            return
+        self._upload_ledger.set_evaluation_contract(
+            self.get_evaluation_id(),
+            self._build_upload_ledger_contract(self._eval_config),
+        )
 
     @validate_args(method_name=Rules.str_non_empty)
     def _validate_eval_type(self, method_name: str) -> None:
@@ -163,6 +242,7 @@ class Evaluator:
         self._validate_close()
         if self._eval_config.eval_type == EvalType.RANKING:
             self._update_ranking_batch_size_before_upload()
+            self._store_upload_ledger_contract()
         self._wait_for_uploads()
         self._process_audio_files_with_verification()
         self._upload_session_json()
@@ -275,6 +355,13 @@ class Evaluator:
         validated_files = self._file_validator.validate_files(files)
         audio_group = self._file_transformer.transform_into_audio_group(validated_files)
         self._ordered_file_groups.append(audio_group)
+        if self._eval_config.resume_upload:
+            try:
+                self._update_ranking_batch_size_before_upload()
+                self._store_upload_ledger_contract()
+            except Exception:
+                self._ordered_file_groups.pop()
+                raise
         for audio in audio_group.audios:
             self._upload_one_file(evaluation_id=self.get_evaluation_id(), audio=audio)
 
@@ -297,16 +384,17 @@ class Evaluator:
         all_audios = [
             audio for group in self._ordered_file_groups for audio in group.audios
         ]
+        audios_for_metadata = self._get_audios_needing_metadata_registration(
+            all_audios
+        )
 
-        for i in range(0, len(all_audios), 500):
-            batch = all_audios[i : i + 500]
-            self._evaluation_service.create_evaluation_files(
-                self.get_evaluation_id(), batch
-            )
+        self._register_metadata_for_audios(audios_for_metadata)
 
-        log.info(f"Verifying {len(all_audios)} files...")
+        audios_for_verification = self._get_audios_needing_verification(all_audios)
+
+        log.info(f"Verifying {len(audios_for_verification)} files...")
         verify_response = self._verify_files_in_batches(
-            self.get_evaluation_id(), all_audios
+            self.get_evaluation_id(), audios_for_verification
         )
 
         if verify_response.all_verified:
@@ -362,7 +450,7 @@ class Evaluator:
             if audio.is_silent
         ]
         if silent_audios:
-            silent_names = [a.path for a in silent_audios]
+            silent_names = [os.path.basename(a.path) for a in silent_audios]
             MAX_DISPLAY = 10
             displayed = ', '.join(silent_names[:MAX_DISPLAY])
             suffix = f" (and {len(silent_names) - MAX_DISPLAY} more)" if len(silent_names) > MAX_DISPLAY else ""
@@ -373,9 +461,28 @@ class Evaluator:
             )
 
         log.info("Triggering file processing...")
-        process_response = self._evaluation_service.process_files(
-            self.get_evaluation_id()
+        process_request_hash = self._finalization_hash(
+            {
+                "evaluation_id": self.get_evaluation_id(),
+                "files": [audio.to_create_file_dict() for audio in all_audios],
+            }
         )
+        if self._upload_ledger is not None and self._upload_ledger.is_processed(
+            self.get_evaluation_id(), process_request_hash
+        ):
+            log.info("Skipping file processing; upload ledger marks it complete.")
+            return
+        process_response = self._evaluation_service.process_files(
+            self.get_evaluation_id(),
+            timeout=self._eval_config.api_timeout,
+            context={"file_count": len(all_audios)},
+        )
+        if self._upload_ledger is not None:
+            self._upload_ledger.mark_processed(
+                self.get_evaluation_id(),
+                process_response.processing_count,
+                process_request_hash,
+            )
         log.info(f"Processing triggered for {process_response.processing_count} files.")
 
     def _verify_files_in_batches(
@@ -393,14 +500,45 @@ class Evaluator:
         all_results: List[FileVerificationResult] = []
         total_verified = 0
         total_failed = 0
+        audios_to_verify: List[Audio] = []
+
+        for audio in audios:
+            row = self._get_ledger_row(audio)
+            if row and row.status == "verified":
+                if not self._ledger_row_matches_local_file(audio, row):
+                    raise ValueError(
+                        "Upload ledger row does not match the current local file for "
+                        "the current upload item. Start a fresh evaluation or remove the stale "
+                        "ledger row before resuming."
+                    )
+                self._hydrate_audio_from_ledger(audio, row)
+                total_verified += 1
+                continue
+            audios_to_verify.append(audio)
 
         batch_size = self._eval_config.verify_batch_size
 
-        for i in range(0, len(audios), batch_size):
-            batch = audios[i : i + batch_size]
-            batch_response = self._evaluation_service.verify_files(evaluation_id, batch)
+        for i in range(0, len(audios_to_verify), batch_size):
+            batch = audios_to_verify[i : i + batch_size]
+            batch_index = i // batch_size
+            batch_response = self._evaluation_service.verify_files(
+                evaluation_id,
+                batch,
+                timeout=self._eval_config.verify_timeout,
+                context={
+                    "batch_index": batch_index,
+                    "batch_size": len(batch),
+                    "batch_start": i,
+                    "total_files": len(audios_to_verify),
+                },
+            )
 
-            all_results.extend(batch_response.results)
+            if self._upload_ledger is None:
+                all_results.extend(batch_response.results)
+            else:
+                all_results.extend(
+                    self._persist_verify_results(evaluation_id, batch_response.results)
+                )
             total_verified += batch_response.verified_count
             total_failed += batch_response.failed_count
 
@@ -417,30 +555,291 @@ class Evaluator:
         failed_names = {r.uploaded_file_name for r in failed_results}
         return [a for a in audios if a.remote_object_name in failed_names]
 
+    def _get_ledger_row(self, audio: Audio) -> Optional[UploadLedgerRow]:
+        if self._upload_ledger is None:
+            return None
+        return self._upload_ledger.get(self.get_evaluation_id(), audio.remote_object_name)
+
+    def _should_skip_upload(self, audio: Audio) -> bool:
+        if self._upload_ledger is None:
+            return False
+
+        file_index = self._assign_file_index(audio)
+        manifest_key = self._build_current_manifest_key(audio)
+        row = self._upload_ledger.upsert_queued_file(
+            self.get_evaluation_id(),
+            audio.remote_object_name,
+            audio.path,
+            file_index=file_index,
+            manifest_key=manifest_key,
+        )
+        self._apply_ledger_remote_identity(audio, row)
+        if not self._ledger_row_matches_local_file(audio, row):
+            if row.status in {"metadata_registering", "metadata_registered", "verified"}:
+                raise ValueError(
+                    "Upload ledger row does not match the current local file for "
+                    "the current upload item. Start a fresh evaluation or remove the stale "
+                    "ledger row before resuming."
+                )
+            row = self._upload_ledger.reset_for_reupload(
+                self.get_evaluation_id(), row.remote_object_name, audio.path
+            )
+        self._hydrate_audio_from_ledger(audio, row)
+        return row.status in {
+            "uploaded",
+            "metadata_registering",
+            "metadata_registered",
+            "verified",
+        }
+
+    def _assign_file_index(self, audio: Audio) -> int:
+        existing = getattr(audio, "_podonos_file_index", None)
+        if existing is not None:
+            return int(existing)
+        file_index = self._next_file_index
+        setattr(audio, "_podonos_file_index", file_index)
+        self._next_file_index += 1
+        return file_index
+
+    def _apply_ledger_remote_identity(
+        self, audio: Audio, row: UploadLedgerRow
+    ) -> None:
+        if audio.remote_object_name == row.remote_object_name:
+            return
+        setattr(audio, "_remote_object_name", row.remote_object_name)
+
+    def _build_current_manifest_key(self, audio: Audio) -> str:
+        content_md5, file_size = calculate_file_md5_base64(audio.path)
+        audio.set_integrity_info(content_md5, file_size)
+        return build_upload_manifest_key(
+            audio.to_create_file_dict(), content_md5, file_size
+        )
+
+    def _ledger_row_matches_local_file(
+        self, audio: Audio, row: UploadLedgerRow
+    ) -> bool:
+        if row.status == "queued":
+            return os.path.abspath(row.local_path) == os.path.abspath(audio.path)
+        if os.path.abspath(row.local_path) != os.path.abspath(audio.path):
+            return False
+        if not row.content_md5 or not row.file_size:
+            return row.status == "upload_failed"
+
+        content_md5, file_size = calculate_file_md5_base64(audio.path)
+        if content_md5 != row.content_md5 or file_size != row.file_size:
+            return False
+        audio.set_integrity_info(content_md5, file_size)
+        if row.status != "upload_failed":
+            manifest_hash = build_upload_manifest_hash(
+                audio.to_create_file_dict(), content_md5, file_size
+            )
+            if row.manifest_hash != manifest_hash:
+                return False
+        return True
+
+    def _get_audios_needing_metadata_registration(
+        self, audios: List[Audio]
+    ) -> List[Audio]:
+        if self._upload_ledger is None:
+            return audios
+
+        audios_for_metadata: List[Audio] = []
+        for audio in audios:
+            row = self._get_ledger_row(audio)
+            if row is None:
+                audios_for_metadata.append(audio)
+                continue
+            self._hydrate_audio_from_ledger(audio, row)
+            if row.status == "uploaded":
+                audios_for_metadata.append(audio)
+        return audios_for_metadata
+
+    def _get_audios_needing_verification(self, audios: List[Audio]) -> List[Audio]:
+        if self._upload_ledger is None:
+            return audios
+
+        audios_for_verification: List[Audio] = []
+        for audio in audios:
+            row = self._get_ledger_row(audio)
+            if row is None:
+                audios_for_verification.append(audio)
+                continue
+            self._hydrate_audio_from_ledger(audio, row)
+            if row.status in {"metadata_registering", "metadata_registered", "verify_failed"}:
+                audios_for_verification.append(audio)
+        return audios_for_verification
+
+    def _register_metadata_for_audios(self, audios: List[Audio]) -> None:
+        if self._upload_ledger is None:
+            for i in range(0, len(audios), 500):
+                batch = audios[i : i + 500]
+                self._evaluation_service.create_evaluation_files(
+                    self.get_evaluation_id(),
+                    batch,
+                    timeout=self._eval_config.api_timeout,
+                    context={
+                        "batch_index": i // 500,
+                        "batch_size": len(batch),
+                        "batch_start": i,
+                        "total_files": len(audios),
+                    },
+                )
+            return
+
+        for i in range(0, len(audios), 500):
+            batch = audios[i : i + 500]
+            batch_to_register: List[Audio] = []
+            for audio in batch:
+                row = self._get_ledger_row(audio)
+                if row is None:
+                    batch_to_register.append(audio)
+                    continue
+                if row.status == "uploaded":
+                    self._upload_ledger.mark_metadata_registering(
+                        self.get_evaluation_id(), audio.remote_object_name
+                    )
+                    batch_to_register.append(audio)
+
+            if not batch_to_register:
+                continue
+
+            try:
+                self._evaluation_service.create_evaluation_files(
+                    self.get_evaluation_id(),
+                    batch_to_register,
+                    timeout=self._eval_config.api_timeout,
+                    context={
+                        "batch_index": i // 500,
+                        "batch_size": len(batch_to_register),
+                        "batch_start": i,
+                        "total_files": len(audios),
+                    },
+                )
+            except Exception as exc:
+                for audio in batch_to_register:
+                    try:
+                        self._upload_ledger.mark_metadata_registration_retry_needed(
+                            self.get_evaluation_id(),
+                            audio.remote_object_name,
+                            type(exc).__name__,
+                            redact_secrets(exc),
+                        )
+                    except Exception as ledger_exc:
+                        log.warning(
+                            "Failed to roll back metadata registration state for "
+                            f"{audio.remote_object_name}: {redact_secrets(ledger_exc)}"
+                        )
+                raise
+            for audio in batch_to_register:
+                self._upload_ledger.mark_metadata_registered(
+                    self.get_evaluation_id(), audio.remote_object_name
+                )
+
+    def _persist_verify_results(
+        self, evaluation_id: str, results: List[FileVerificationResult]
+    ) -> List[FileVerificationResult]:
+        if self._upload_ledger is None:
+            return results
+
+        failed_results: List[FileVerificationResult] = []
+        for result in results:
+            try:
+                if result.verified:
+                    self._upload_ledger.mark_verified(
+                        evaluation_id, result.uploaded_file_name
+                    )
+                else:
+                    existing = self._upload_ledger.get(
+                        evaluation_id, result.uploaded_file_name
+                    )
+                    error_type = result.error.code if result.error else "VERIFY_FAILED"
+                    error_message = (
+                        result.error.message if result.error else "Verification failed"
+                    )
+                    if existing and existing.status == "metadata_registering":
+                        self._upload_ledger.mark_metadata_registration_retry_needed(
+                            evaluation_id,
+                            result.uploaded_file_name,
+                            error_type,
+                            error_message,
+                        )
+                    else:
+                        self._upload_ledger.mark_verify_failed(
+                            evaluation_id,
+                            result.uploaded_file_name,
+                            error_type,
+                            error_message,
+                        )
+                    failed_results.append(result)
+            except Exception as exc:
+                log.warning(
+                    f"Failed to persist upload ledger verification result for "
+                    f"{result.uploaded_file_name}: {redact_secrets(exc)}"
+                )
+                if not result.verified:
+                    failed_results.append(result)
+        return failed_results
+
+    def _hydrate_audio_from_ledger(self, audio: Audio, row: UploadLedgerRow) -> None:
+        if row.content_md5 and row.file_size:
+            try:
+                audio.set_integrity_info(row.content_md5, row.file_size)
+            except Exception as exc:
+                log.warning(
+                    f"Failed to hydrate integrity info from upload ledger for "
+                    f"{row.remote_object_name}: {redact_secrets(exc)}"
+                )
+        if row.upload_start_at and row.upload_finish_at:
+            try:
+                audio.set_upload_at(row.upload_start_at, row.upload_finish_at)
+            except Exception as exc:
+                log.warning(
+                    f"Failed to hydrate upload times from upload ledger for "
+                    f"{row.remote_object_name}: {redact_secrets(exc)}"
+                )
+
     def _retry_failed_uploads(self, failed_audios: List[Audio]) -> None:
-        log.info(f"Re-uploading {len(failed_audios)} failed files...")
+        metadata_retry_audios: List[Audio] = []
+        upload_retry_audios: List[Audio] = []
+
+        for audio in failed_audios:
+            row = self._get_ledger_row(audio)
+            if self._upload_ledger is not None and row and row.status == "uploaded":
+                metadata_retry_audios.append(audio)
+            else:
+                upload_retry_audios.append(audio)
+
+        if metadata_retry_audios:
+            log.info(
+                f"Retrying metadata registration for "
+                f"{len(metadata_retry_audios)} file(s)..."
+            )
+            self._register_metadata_for_audios(metadata_retry_audios)
+
+        if not upload_retry_audios:
+            return
+
+        log.info(f"Re-uploading {len(upload_retry_audios)} failed files...")
 
         retry_manager = UploadManager(
             evaluation_service=self._evaluation_service,
-            max_workers=min(len(failed_audios), self._eval_config.max_upload_workers),
+            max_workers=min(len(upload_retry_audios), self._eval_config.max_upload_workers),
+            api_timeout=self._eval_config.api_timeout,
+            upload_timeout=self._eval_config.upload_timeout,
+            upload_ledger=self._upload_ledger,
         )
 
-        for audio in failed_audios:
+        for audio in upload_retry_audios:
             retry_manager.add_file_to_queue(self.get_evaluation_id(), audio)
 
         retry_manager.wait_and_close()
-
-        for i in range(0, len(failed_audios), 500):
-            batch = failed_audios[i : i + 500]
-            self._evaluation_service.create_evaluation_files(
-                self.get_evaluation_id(), batch
-            )
+        self._register_metadata_for_audios(upload_retry_audios)
 
     def _find_original_name(self, remote_object_name: str) -> str:
         for group in self._ordered_file_groups:
             for audio in group.audios:
                 if audio.remote_object_name == remote_object_name:
-                    return audio.path
+                    return os.path.basename(audio.path)
         return remote_object_name
 
     def _process_upload_times(self) -> None:
@@ -475,9 +874,33 @@ class Evaluator:
 
     def _upload_session_json(self) -> None:
         """Upload the session JSON data."""
+        session_json_hash = self._finalization_hash(self._session_json_payload())
+        if self._upload_ledger is not None and self._upload_ledger.is_session_json_uploaded(
+            self.get_evaluation_id(), session_json_hash
+        ):
+            log.info("Skipping session JSON upload; upload ledger marks it complete.")
+            return
         self._evaluation_service.upload_session_json(
             self.get_evaluation_id(), self._eval_config, self._ordered_file_groups
         )
+        if self._upload_ledger is not None:
+            self._upload_ledger.mark_session_json_uploaded(
+                self.get_evaluation_id(), session_json_hash
+            )
+
+    def _session_json_payload(self) -> Dict[str, Any]:
+        session_json = self._eval_config.to_dict()
+        session_json["files"] = [group.to_dict() for group in self._ordered_file_groups]
+        return session_json
+
+    def _finalization_hash(self, payload: Dict[str, Any]) -> str:
+        canonical = json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        )
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
     def _cleanup(self) -> None:
         """Clean up the evaluation session."""
@@ -486,13 +909,28 @@ class Evaluator:
 
     @validate_args(eval_config=Rules.instance_of(EvalConfig))
     def _set_evaluation(self, eval_config: EvalConfig) -> EvaluationEntity:
+        if eval_config.resume_evaluation_id:
+            evaluation = self._evaluation_service.get_evaluation(
+                eval_config.resume_evaluation_id,
+                timeout=eval_config.api_timeout,
+                context={"operation": "resume_evaluation"},
+            )
+            if evaluation.batch_size != eval_config.eval_batch_size:
+                raise ValueError(
+                    "Backend evaluation batch_size does not match the upload "
+                    "ledger contract: "
+                    f"backend={evaluation.batch_size}, "
+                    f"ledger={eval_config.eval_batch_size}."
+                )
+            eval_config.eval_id = evaluation.id
+            return evaluation
         if eval_config.eval_template_id:
             return self._evaluation_service.create_from_template(eval_config)
         return self._evaluation_service.create(eval_config)
 
     @validate_args(evaluation_id=Rules.str_non_empty, audio=Rules.instance_of(Audio))
     def _upload_one_file(self, evaluation_id: str, audio: Audio) -> None:
-        log.debug(f"Adding to queue: {audio.path}")
+        log.debug("Adding file to upload queue")
         if not self._eval_config:
             raise ValueError("No evaluation session is open.")
 
@@ -501,9 +939,18 @@ class Evaluator:
             self._upload_manager = UploadManager(
                 evaluation_service=self._evaluation_service,
                 max_workers=self._eval_config.max_upload_workers,
+                api_timeout=self._eval_config.api_timeout,
+                upload_timeout=self._eval_config.upload_timeout,
+                upload_ledger=self._upload_ledger,
             )
 
         if self._upload_manager:
+            if self._should_skip_upload(audio):
+                log.info(
+                    f"Skipping upload for {audio.remote_object_name}; "
+                    "upload ledger already has completed upload state."
+                )
+                return
             self._upload_manager.add_file_to_queue(evaluation_id, audio)
 
     def _update_ranking_batch_size_before_upload(self) -> None:
@@ -516,6 +963,16 @@ class Evaluator:
         if group_size < 2:
             raise ValueError("RANKING requires at least two files per group")
 
+        if self._eval_config.resume_evaluation_id:
+            expected_size = self._eval_config.eval_batch_size
+            if group_size != expected_size:
+                raise ValueError(
+                    "Resumed RANKING evaluation group size does not match the "
+                    f"original evaluation contract: expected {expected_size}, "
+                    f"got {group_size}."
+                )
+            return
+
         payload: Dict[str, Any] = {
             "id": self.get_evaluation_id(),
             "language": self._eval_config.eval_language.value,
@@ -525,6 +982,12 @@ class Evaluator:
             "meta_data": {},
         }
         self._evaluation_service.update_specific_fields(
-            self.get_evaluation_id(), payload
+            self.get_evaluation_id(),
+            payload,
+            timeout=self._eval_config.api_timeout,
+            context={
+                "operation": "ranking_batch_size_resolution",
+                "batch_size": group_size,
+            },
         )
         self._eval_config.eval_batch_size = group_size

--- a/podonos/core/upload_ledger.py
+++ b/podonos/core/upload_ledger.py
@@ -26,6 +26,16 @@ LEDGER_STATUSES = {
 }
 
 
+class _ClosingSQLiteConnection(sqlite3.Connection):
+    """SQLite connection that closes when used as a context manager."""
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> bool:
+        try:
+            return bool(super().__exit__(exc_type, exc_value, traceback))
+        finally:
+            self.close()
+
+
 def build_upload_manifest_key(
     file_contract: Dict[str, Any], content_md5: str, file_size: int
 ) -> str:
@@ -969,6 +979,7 @@ class UploadLedger:
             self.path,
             timeout=self.busy_timeout_ms / 1000.0,
             isolation_level=None,
+            factory=_ClosingSQLiteConnection,
         )
         conn.row_factory = sqlite3.Row
         conn.execute(f"PRAGMA busy_timeout = {self.busy_timeout_ms}")

--- a/podonos/core/upload_ledger.py
+++ b/podonos/core/upload_ledger.py
@@ -1,0 +1,1086 @@
+from __future__ import annotations
+
+import os
+import hashlib
+import json
+import sqlite3
+import stat
+import threading
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterator, List, Optional, Sequence
+
+from podonos.common.redaction import redact_secrets
+
+
+LEDGER_STATUSES = {
+    "queued",
+    "md5_ready",
+    "uploaded",
+    "metadata_registering",
+    "metadata_registered",
+    "verified",
+    "upload_failed",
+    "verify_failed",
+}
+
+
+def build_upload_manifest_key(
+    file_contract: Dict[str, Any], content_md5: str, file_size: int
+) -> str:
+    """Hash the stable local-file + evaluation metadata identity for resume."""
+
+    stable_contract = dict(file_contract)
+    stable_contract.pop("uploaded_file_name", None)
+    payload = {
+        "content_md5": content_md5,
+        "file_size": file_size,
+        "file_contract": stable_contract,
+    }
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def build_upload_manifest_hash(
+    file_contract: Dict[str, Any], content_md5: str, file_size: int
+) -> str:
+    """Hash the immutable local-file + metadata contract used for resume safety."""
+
+    payload = {
+        "content_md5": content_md5,
+        "file_size": file_size,
+        "file_contract": file_contract,
+    }
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+@dataclass(frozen=True)
+class UploadLedgerRow:
+    evaluation_id: str
+    remote_object_name: str
+    local_path: str
+    status: str
+    created_at: str
+    updated_at: str
+    file_index: Optional[int] = None
+    content_md5: Optional[str] = None
+    file_size: Optional[int] = None
+    manifest_key: Optional[str] = None
+    manifest_hash: Optional[str] = None
+    upload_start_at: Optional[str] = None
+    upload_finish_at: Optional[str] = None
+    error_type: Optional[str] = None
+    error_message: Optional[str] = None
+
+
+class InvalidUploadLedgerTransition(ValueError):
+    """Raised when a ledger row is advanced through an invalid status transition."""
+
+
+class UploadLedger:
+    """SQLite upload progress ledger for one SDK process with multiple threads.
+
+    Concurrency model:
+    - This class is intentionally scoped to a single Python process. Multi-process
+      writers are out of scope for the first opt-in resumability implementation.
+    - Each operation opens a short-lived SQLite connection and owns one per-row
+      transaction. A process-local RLock serializes writes made through the same
+      UploadLedger instance, while SQLite's finite busy timeout protects callers
+      from blocking indefinitely if another connection holds the database lock.
+    - Ledger data is SDK-local progress state only; it is never backend truth.
+    """
+
+    def __init__(
+        self,
+        path: str,
+        busy_timeout_ms: int = 1000,
+    ) -> None:
+        if not isinstance(path, str) or not path.strip():
+            raise ValueError("path must be a non-empty string")
+        if busy_timeout_ms < 1:
+            raise ValueError("busy_timeout_ms must be >= 1")
+
+        self._requested_path = os.path.abspath(path)
+        self.path = self._requested_path
+        self.busy_timeout_ms = busy_timeout_ms
+        self._lock = threading.RLock()
+        self._initialize_schema()
+
+    def upsert_queued_file(
+        self,
+        evaluation_id: str,
+        remote_object_name: str,
+        local_path: str,
+        file_index: Optional[int] = None,
+        manifest_key: Optional[str] = None,
+    ) -> UploadLedgerRow:
+        """Insert a queued row if missing; never downgrade an existing row."""
+
+        self._validate_identity(evaluation_id, remote_object_name)
+        if not isinstance(local_path, str) or not local_path:
+            raise ValueError("local_path must be a non-empty string")
+        local_path = os.path.abspath(local_path)
+        if file_index is not None and (
+            not isinstance(file_index, int) or file_index < 0
+        ):
+            raise ValueError("file_index must be a non-negative integer or None")
+        if manifest_key is not None and (
+            not isinstance(manifest_key, str) or not manifest_key
+        ):
+            raise ValueError("manifest_key must be a non-empty string or None")
+
+        def _op(conn: sqlite3.Connection) -> UploadLedgerRow:
+            existing = self._fetch_row(conn, evaluation_id, remote_object_name)
+            if existing:
+                return existing
+            existing_by_index = (
+                self._fetch_row_by_file_index(conn, evaluation_id, file_index)
+                if file_index is not None
+                else None
+            )
+            if manifest_key is not None:
+                existing_by_manifest = self._fetch_rows_by_manifest_key(
+                    conn, evaluation_id, manifest_key
+                )
+                if len(existing_by_manifest) == 1:
+                    manifest_row = existing_by_manifest[0]
+                    if file_index is None:
+                        return manifest_row
+                    if existing_by_index is not None:
+                        if existing_by_index.manifest_key == manifest_key:
+                            return existing_by_index
+                        return manifest_row
+                    # A single manifest match without a matching file index is
+                    # ambiguous: it may be a deliberate duplicate occurrence in
+                    # the same run. Prefer inserting a distinct row over
+                    # under-uploading by collapsing two logical files.
+                elif len(existing_by_manifest) > 1:
+                    if existing_by_index is not None:
+                        if existing_by_index.manifest_key in (None, manifest_key):
+                            return existing_by_index
+                        raise ValueError(
+                            "Upload ledger file_index matches a different file "
+                            "manifest; resume with the original files or start a "
+                            "fresh evaluation."
+                        )
+                    if file_index is None:
+                        raise ValueError(
+                            "Upload ledger manifest identity is ambiguous; provide "
+                            "a file_index or start a fresh evaluation."
+                        )
+            if existing_by_index:
+                if (
+                    manifest_key is not None
+                    and existing_by_index.manifest_key is not None
+                    and existing_by_index.manifest_key != manifest_key
+                ):
+                    raise ValueError(
+                        "Upload ledger file_index matches a different file "
+                        "manifest; resume with the original files or start a "
+                        "fresh evaluation."
+                    )
+                return existing_by_index
+
+            now = self._now()
+            conn.execute(
+                """
+                INSERT INTO upload_ledger (
+                    evaluation_id,
+                    remote_object_name,
+                    local_path,
+                    file_index,
+                    manifest_key,
+                    status,
+                    created_at,
+                    updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    evaluation_id,
+                    remote_object_name,
+                    local_path,
+                    file_index,
+                    manifest_key,
+                    "queued",
+                    now,
+                    now,
+                ),
+            )
+            row = self._fetch_row(conn, evaluation_id, remote_object_name)
+            assert row is not None
+            return row
+
+        return self._write_transaction(_op)
+
+    def reset_for_reupload(
+        self,
+        evaluation_id: str,
+        remote_object_name: str,
+        local_path: str,
+    ) -> UploadLedgerRow:
+        """Reset a non-final row so the same remote object can be uploaded again."""
+
+        if not isinstance(local_path, str) or not local_path:
+            raise ValueError("local_path must be a non-empty string")
+        local_path = os.path.abspath(local_path)
+        return self._transition(
+            evaluation_id,
+            remote_object_name,
+            target_status="queued",
+            allowed_from=tuple(LEDGER_STATUSES),
+            updates={
+                "local_path": local_path,
+                "content_md5": None,
+                "file_size": None,
+                "manifest_key": None,
+                "manifest_hash": None,
+                "upload_start_at": None,
+                "upload_finish_at": None,
+                "error_type": None,
+                "error_message": None,
+            },
+        )
+
+    def mark_md5_ready(
+        self,
+        evaluation_id: str,
+        remote_object_name: str,
+        content_md5: str,
+        file_size: int,
+        manifest_hash: Optional[str] = None,
+        manifest_key: Optional[str] = None,
+    ) -> UploadLedgerRow:
+        if not isinstance(content_md5, str) or not content_md5:
+            raise ValueError("content_md5 must be a non-empty string")
+        if not isinstance(file_size, int) or file_size < 1:
+            raise ValueError("file_size must be a positive integer")
+        if manifest_hash is not None and (
+            not isinstance(manifest_hash, str) or not manifest_hash
+        ):
+            raise ValueError("manifest_hash must be a non-empty string or None")
+        if manifest_key is not None and (
+            not isinstance(manifest_key, str) or not manifest_key
+        ):
+            raise ValueError("manifest_key must be a non-empty string or None")
+        updates: Dict[str, Any] = {"content_md5": content_md5, "file_size": file_size}
+        if manifest_key is not None:
+            updates["manifest_key"] = manifest_key
+        if manifest_hash is not None:
+            updates["manifest_hash"] = manifest_hash
+        return self._transition(
+            evaluation_id,
+            remote_object_name,
+            target_status="md5_ready",
+            allowed_from=("queued", "md5_ready", "upload_failed", "verify_failed"),
+            updates=updates,
+        )
+
+    def mark_uploaded(
+        self,
+        evaluation_id: str,
+        remote_object_name: str,
+        upload_start_at: str,
+        upload_finish_at: str,
+    ) -> UploadLedgerRow:
+        if not isinstance(upload_start_at, str) or not upload_start_at:
+            raise ValueError("upload_start_at must be a non-empty string")
+        if not isinstance(upload_finish_at, str) or not upload_finish_at:
+            raise ValueError("upload_finish_at must be a non-empty string")
+        return self._transition(
+            evaluation_id,
+            remote_object_name,
+            target_status="uploaded",
+            allowed_from=("md5_ready", "uploaded"),
+            updates={
+                "upload_start_at": upload_start_at,
+                "upload_finish_at": upload_finish_at,
+                "error_type": None,
+                "error_message": None,
+            },
+        )
+
+    def mark_metadata_registered(
+        self, evaluation_id: str, remote_object_name: str
+    ) -> UploadLedgerRow:
+        return self._transition(
+            evaluation_id,
+            remote_object_name,
+            target_status="metadata_registered",
+            allowed_from=(
+                "uploaded",
+                "metadata_registering",
+                "metadata_registered",
+                "verify_failed",
+            ),
+            updates={"error_type": None, "error_message": None},
+        )
+
+    def mark_metadata_registering(
+        self, evaluation_id: str, remote_object_name: str
+    ) -> UploadLedgerRow:
+        return self._transition(
+            evaluation_id,
+            remote_object_name,
+            target_status="metadata_registering",
+            allowed_from=("uploaded", "metadata_registering"),
+            updates={"error_type": None, "error_message": None},
+        )
+
+    def mark_metadata_registration_retry_needed(
+        self,
+        evaluation_id: str,
+        remote_object_name: str,
+        error_type: str,
+        error_message: str,
+    ) -> UploadLedgerRow:
+        return self._transition(
+            evaluation_id,
+            remote_object_name,
+            target_status="uploaded",
+            allowed_from=("metadata_registering",),
+            updates={
+                "error_type": redact_secrets(error_type),
+                "error_message": redact_secrets(error_message),
+            },
+        )
+
+    def mark_verified(
+        self, evaluation_id: str, remote_object_name: str
+    ) -> UploadLedgerRow:
+        return self._transition(
+            evaluation_id,
+            remote_object_name,
+            target_status="verified",
+            allowed_from=(
+                "uploaded",
+                "metadata_registering",
+                "metadata_registered",
+                "verify_failed",
+                "verified",
+            ),
+            updates={"error_type": None, "error_message": None},
+        )
+
+    def mark_upload_failed(
+        self,
+        evaluation_id: str,
+        remote_object_name: str,
+        error_type: str,
+        error_message: str,
+    ) -> UploadLedgerRow:
+        return self._transition(
+            evaluation_id,
+            remote_object_name,
+            target_status="upload_failed",
+            allowed_from=tuple(LEDGER_STATUSES),
+            updates={
+                "error_type": redact_secrets(error_type),
+                "error_message": redact_secrets(error_message),
+            },
+        )
+
+    def mark_verify_failed(
+        self,
+        evaluation_id: str,
+        remote_object_name: str,
+        error_type: str,
+        error_message: str,
+    ) -> UploadLedgerRow:
+        return self._transition(
+            evaluation_id,
+            remote_object_name,
+            target_status="verify_failed",
+            allowed_from=("uploaded", "metadata_registered", "verify_failed"),
+            updates={
+                "error_type": redact_secrets(error_type),
+                "error_message": redact_secrets(error_message),
+            },
+        )
+
+    def get(
+        self, evaluation_id: str, remote_object_name: str
+    ) -> Optional[UploadLedgerRow]:
+        self._validate_identity(evaluation_id, remote_object_name)
+        with self._connect() as conn:
+            return self._fetch_row(conn, evaluation_id, remote_object_name)
+
+    def list_by_status(
+        self, evaluation_id: str, status: str
+    ) -> List[UploadLedgerRow]:
+        self._validate_status(status)
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT * FROM upload_ledger
+                WHERE evaluation_id = ? AND status = ?
+                ORDER BY remote_object_name
+                """,
+                (evaluation_id, status),
+            ).fetchall()
+            return [self._row_from_sql(row) for row in rows]
+
+    def counts_by_status(self, evaluation_id: str) -> Dict[str, int]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT status, COUNT(*) AS count
+                FROM upload_ledger
+                WHERE evaluation_id = ?
+                GROUP BY status
+                """,
+                (evaluation_id,),
+            ).fetchall()
+        counts = {status: 0 for status in LEDGER_STATUSES}
+        counts.update({str(row["status"]): int(row["count"]) for row in rows})
+        return counts
+
+    def mark_processed(
+        self,
+        evaluation_id: str,
+        processing_count: int = 0,
+        request_hash: Optional[str] = None,
+    ) -> None:
+        if not isinstance(evaluation_id, str) or not evaluation_id:
+            raise ValueError("evaluation_id must be a non-empty string")
+        if not isinstance(processing_count, int) or processing_count < 0:
+            raise ValueError("processing_count must be a non-negative integer")
+        if request_hash is not None and (
+            not isinstance(request_hash, str) or not request_hash
+        ):
+            raise ValueError("request_hash must be a non-empty string or None")
+
+        def _op(conn: sqlite3.Connection) -> None:
+            now = self._now()
+            conn.execute(
+                """
+                INSERT INTO upload_ledger_finalization (
+                    evaluation_id,
+                    processed_at,
+                    processing_count,
+                    processed_request_hash,
+                    created_at,
+                    updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT(evaluation_id) DO UPDATE SET
+                    processed_at = excluded.processed_at,
+                    processing_count = excluded.processing_count,
+                    processed_request_hash = excluded.processed_request_hash,
+                    updated_at = excluded.updated_at
+                """,
+                (evaluation_id, now, processing_count, request_hash, now, now),
+            )
+
+        self._write_transaction(_op)
+
+    def is_processed(
+        self, evaluation_id: str, request_hash: Optional[str] = None
+    ) -> bool:
+        return self._finalization_column_matches(
+            evaluation_id, "processed_at", "processed_request_hash", request_hash
+        )
+
+    def mark_session_json_uploaded(
+        self, evaluation_id: str, session_json_hash: Optional[str] = None
+    ) -> None:
+        if not isinstance(evaluation_id, str) or not evaluation_id:
+            raise ValueError("evaluation_id must be a non-empty string")
+        if session_json_hash is not None and (
+            not isinstance(session_json_hash, str) or not session_json_hash
+        ):
+            raise ValueError("session_json_hash must be a non-empty string or None")
+
+        def _op(conn: sqlite3.Connection) -> None:
+            now = self._now()
+            conn.execute(
+                """
+                INSERT INTO upload_ledger_finalization (
+                    evaluation_id,
+                    session_json_uploaded_at,
+                    session_json_hash,
+                    created_at,
+                    updated_at
+                ) VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(evaluation_id) DO UPDATE SET
+                    session_json_uploaded_at = excluded.session_json_uploaded_at,
+                    session_json_hash = excluded.session_json_hash,
+                    updated_at = excluded.updated_at
+                """,
+                (evaluation_id, now, session_json_hash, now, now),
+            )
+
+        self._write_transaction(_op)
+
+    def is_session_json_uploaded(
+        self, evaluation_id: str, session_json_hash: Optional[str] = None
+    ) -> bool:
+        return self._finalization_column_matches(
+            evaluation_id,
+            "session_json_uploaded_at",
+            "session_json_hash",
+            session_json_hash,
+        )
+
+    @contextmanager
+    def _transaction(self) -> Iterator[sqlite3.Connection]:
+        """Private transaction helper used by ledger operations and atomicity tests."""
+
+        with self._lock:
+            conn = self._connect()
+            try:
+                conn.execute("BEGIN IMMEDIATE")
+                yield conn
+            except Exception:
+                conn.rollback()
+                raise
+            else:
+                conn.commit()
+            finally:
+                conn.close()
+
+    def _write_transaction(self, callback: Any) -> Any:
+        with self._transaction() as conn:
+            return callback(conn)
+
+    def _transition(
+        self,
+        evaluation_id: str,
+        remote_object_name: str,
+        target_status: str,
+        allowed_from: Sequence[str],
+        updates: Dict[str, Any],
+    ) -> UploadLedgerRow:
+        self._validate_identity(evaluation_id, remote_object_name)
+        self._validate_status(target_status)
+        for status in allowed_from:
+            self._validate_status(status)
+
+        def _op(conn: sqlite3.Connection) -> UploadLedgerRow:
+            row = self._fetch_row(conn, evaluation_id, remote_object_name)
+            if row is None:
+                raise KeyError(
+                    f"No upload ledger row for {evaluation_id}/{remote_object_name}"
+                )
+            if row.status not in allowed_from:
+                raise InvalidUploadLedgerTransition(
+                    f"Cannot transition {remote_object_name} from {row.status} "
+                    f"to {target_status}"
+                )
+
+            now = self._now()
+            update_values = {**updates, "status": target_status, "updated_at": now}
+            assignments = ", ".join(f"{column} = ?" for column in update_values)
+            params: List[Any] = list(update_values.values())
+            params.extend([evaluation_id, remote_object_name])
+            conn.execute(
+                f"""
+                UPDATE upload_ledger
+                SET {assignments}
+                WHERE evaluation_id = ? AND remote_object_name = ?
+                """,
+                params,
+            )
+            updated = self._fetch_row(conn, evaluation_id, remote_object_name)
+            assert updated is not None
+            return updated
+
+        return self._write_transaction(_op)
+
+    def get_evaluation_contract(self, evaluation_id: str) -> Optional[Dict[str, Any]]:
+        if not isinstance(evaluation_id, str) or not evaluation_id:
+            raise ValueError("evaluation_id must be a non-empty string")
+        with self._connect() as conn:
+            row = conn.execute(
+                """
+                SELECT contract_json
+                FROM upload_ledger_contracts
+                WHERE evaluation_id = ?
+                """,
+                (evaluation_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return json.loads(str(row["contract_json"]))
+
+    def set_evaluation_contract(
+        self,
+        evaluation_id: str,
+        contract: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        if not isinstance(evaluation_id, str) or not evaluation_id:
+            raise ValueError("evaluation_id must be a non-empty string")
+        if not isinstance(contract, dict) or not contract:
+            raise ValueError("contract must be a non-empty dictionary")
+
+        contract_json = json.dumps(contract, sort_keys=True, separators=(",", ":"))
+
+        def _op(conn: sqlite3.Connection) -> Dict[str, Any]:
+            now = self._now()
+            conn.execute(
+                """
+                INSERT INTO upload_ledger_contracts (
+                    evaluation_id,
+                    contract_json,
+                    created_at,
+                    updated_at
+                ) VALUES (?, ?, ?, ?)
+                ON CONFLICT(evaluation_id) DO UPDATE SET
+                    contract_json = excluded.contract_json,
+                    updated_at = excluded.updated_at
+                """,
+                (evaluation_id, contract_json, now, now),
+            )
+            return contract
+
+        return self._write_transaction(_op)
+
+    def _initialize_schema(self) -> None:
+        self._ensure_safe_parent_directory()
+        self._ensure_safe_file_path()
+        old_umask: Optional[int] = None
+        if os.name != "nt" and not os.path.exists(self.path):
+            old_umask = os.umask(0o177)
+        try:
+            with self._connect() as conn:
+                conn.executescript(
+                    """
+                    CREATE TABLE IF NOT EXISTS upload_ledger (
+                        evaluation_id TEXT NOT NULL,
+                        remote_object_name TEXT NOT NULL,
+                        local_path TEXT NOT NULL,
+                        file_index INTEGER,
+                        status TEXT NOT NULL,
+                        content_md5 TEXT,
+                        file_size INTEGER,
+                        manifest_key TEXT,
+                        manifest_hash TEXT,
+                        upload_start_at TEXT,
+                        upload_finish_at TEXT,
+                        error_type TEXT,
+                        error_message TEXT,
+                        created_at TEXT NOT NULL,
+                        updated_at TEXT NOT NULL,
+                        PRIMARY KEY (evaluation_id, remote_object_name),
+                        CHECK (status IN (
+                            'queued',
+                            'md5_ready',
+                            'uploaded',
+                            'metadata_registering',
+                            'metadata_registered',
+                            'verified',
+                            'upload_failed',
+                            'verify_failed'
+                        ))
+                    );
+                    CREATE INDEX IF NOT EXISTS idx_upload_ledger_status
+                        ON upload_ledger (evaluation_id, status);
+                    CREATE TABLE IF NOT EXISTS upload_ledger_contracts (
+                        evaluation_id TEXT PRIMARY KEY,
+                        contract_json TEXT NOT NULL,
+                        created_at TEXT NOT NULL,
+                        updated_at TEXT NOT NULL
+                    );
+                    CREATE TABLE IF NOT EXISTS upload_ledger_finalization (
+                        evaluation_id TEXT PRIMARY KEY,
+                        processed_at TEXT,
+                        processing_count INTEGER,
+                        processed_request_hash TEXT,
+                        session_json_uploaded_at TEXT,
+                        session_json_hash TEXT,
+                        created_at TEXT NOT NULL,
+                        updated_at TEXT NOT NULL
+                    );
+                    """
+                )
+                self._ensure_column(conn, "file_index", "INTEGER")
+                self._ensure_column(conn, "manifest_key", "TEXT")
+                self._ensure_column(conn, "manifest_hash", "TEXT")
+                self._ensure_table_column(
+                    conn,
+                    "upload_ledger_finalization",
+                    "processed_request_hash",
+                    "TEXT",
+                )
+                self._ensure_table_column(
+                    conn,
+                    "upload_ledger_finalization",
+                    "session_json_hash",
+                    "TEXT",
+                )
+                self._migrate_status_check_if_needed(conn)
+                self._deduplicate_file_indexes(conn)
+                conn.execute(
+                    """
+                    CREATE INDEX IF NOT EXISTS idx_upload_ledger_status
+                        ON upload_ledger (evaluation_id, status)
+                    """
+                )
+                conn.execute(
+                    """
+                    CREATE INDEX IF NOT EXISTS idx_upload_ledger_file_index
+                        ON upload_ledger (evaluation_id, file_index)
+                    """
+                )
+                conn.execute(
+                    """
+                    DROP INDEX IF EXISTS ux_upload_ledger_evaluation_file_index
+                    """
+                )
+                conn.execute(
+                    """
+                    CREATE INDEX IF NOT EXISTS idx_upload_ledger_manifest_key
+                        ON upload_ledger (evaluation_id, manifest_key)
+                    """
+                )
+        finally:
+            if old_umask is not None:
+                os.umask(old_umask)
+        self._harden_permissions()
+
+    def _ensure_safe_parent_directory(self) -> None:
+        parent = os.path.dirname(self._requested_path)
+        if not parent:
+            return
+        if os.name == "nt":
+            os.makedirs(parent, exist_ok=True)
+            return
+
+        root = os.path.abspath(os.sep)
+        rel_parent = os.path.relpath(parent, root)
+        rel_parts = [] if rel_parent == "." else rel_parent.split(os.sep)
+        dir_flags = os.O_RDONLY
+        if hasattr(os, "O_DIRECTORY"):
+            dir_flags |= os.O_DIRECTORY
+        if hasattr(os, "O_NOFOLLOW"):
+            dir_flags |= os.O_NOFOLLOW
+
+        dir_fds: List[int] = []
+        try:
+            current_path = root
+            current_fd = os.open(root, dir_flags)
+            dir_fds.append(current_fd)
+            for part in rel_parts:
+                if part in {"", ".", ".."}:
+                    raise ValueError("upload_state_path parent is invalid")
+                candidate_path = os.path.join(current_path, part)
+                try:
+                    os.mkdir(part, 0o700, dir_fd=current_fd)
+                except FileExistsError:
+                    pass
+                try:
+                    next_fd = os.open(part, dir_flags, dir_fd=current_fd)
+                    current_path = candidate_path
+                except OSError:
+                    if not self._is_allowed_platform_symlink(candidate_path):
+                        raise
+                    resolved_candidate = os.path.realpath(candidate_path)
+                    next_fd = os.open(resolved_candidate, dir_flags)
+                    current_path = resolved_candidate
+                current_fd = next_fd
+                dir_fds.append(current_fd)
+        except OSError as exc:
+            raise ValueError(
+                "upload_state_path parent must not contain symlinks"
+            ) from exc
+        finally:
+            for fd in reversed(dir_fds):
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+
+    @staticmethod
+    def _is_allowed_platform_symlink(path: str) -> bool:
+        """Allow macOS system temp aliases while rejecting caller-created links."""
+
+        allowed_aliases = {
+            "/var": "/private/var",
+            "/tmp": "/private/tmp",
+        }
+        expected_target = allowed_aliases.get(path)
+        if expected_target is None:
+            return False
+        return os.path.islink(path) and os.path.realpath(path) == expected_target
+
+    def _ensure_safe_file_path(self) -> None:
+        if os.name == "nt":
+            return
+        try:
+            requested_stat = os.lstat(self._requested_path)
+            if stat.S_ISLNK(requested_stat.st_mode):
+                raise ValueError("upload_state_path must not be a symlink")
+            path_stat = os.lstat(self._requested_path)
+        except FileNotFoundError:
+            flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
+            if hasattr(os, "O_NOFOLLOW"):
+                flags |= os.O_NOFOLLOW
+            try:
+                fd = os.open(self._requested_path, flags, 0o600)
+            except FileExistsError:
+                self._ensure_safe_file_path()
+                return
+            except OSError as exc:
+                raise ValueError(
+                    "upload_state_path must not be a symlink or unsafe file path"
+                ) from exc
+            else:
+                os.close(fd)
+            return
+
+        if stat.S_ISLNK(path_stat.st_mode):
+            raise ValueError("upload_state_path must not be a symlink")
+        if not stat.S_ISREG(path_stat.st_mode):
+            raise ValueError("upload_state_path must be a regular file")
+
+    def _ensure_column(
+        self, conn: sqlite3.Connection, column_name: str, column_type: str
+    ) -> None:
+        self._ensure_table_column(conn, "upload_ledger", column_name, column_type)
+
+    def _ensure_table_column(
+        self,
+        conn: sqlite3.Connection,
+        table_name: str,
+        column_name: str,
+        column_type: str,
+    ) -> None:
+        if not table_name.replace("_", "").isalnum():
+            raise ValueError("table_name must contain only alphanumeric characters and underscores")
+        if not column_name.replace("_", "").isalnum():
+            raise ValueError("column_name must contain only alphanumeric characters and underscores")
+        existing_columns = {
+            str(row["name"])
+            for row in conn.execute(f"PRAGMA table_info({table_name})").fetchall()
+        }
+        if column_name not in existing_columns:
+            conn.execute(
+                f"ALTER TABLE {table_name} ADD COLUMN {column_name} {column_type}"
+            )
+
+    def _migrate_status_check_if_needed(self, conn: sqlite3.Connection) -> None:
+        row = conn.execute(
+            """
+            SELECT sql FROM sqlite_master
+            WHERE type = 'table' AND name = 'upload_ledger'
+            """
+        ).fetchone()
+        if row is None or "metadata_registering" in str(row["sql"]):
+            return
+
+        conn.executescript(
+            """
+            ALTER TABLE upload_ledger RENAME TO upload_ledger_old;
+            CREATE TABLE upload_ledger (
+                evaluation_id TEXT NOT NULL,
+                remote_object_name TEXT NOT NULL,
+                local_path TEXT NOT NULL,
+                file_index INTEGER,
+                status TEXT NOT NULL,
+                content_md5 TEXT,
+                file_size INTEGER,
+                manifest_key TEXT,
+                manifest_hash TEXT,
+                upload_start_at TEXT,
+                upload_finish_at TEXT,
+                error_type TEXT,
+                error_message TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY (evaluation_id, remote_object_name),
+                CHECK (status IN (
+                    'queued',
+                    'md5_ready',
+                    'uploaded',
+                    'metadata_registering',
+                    'metadata_registered',
+                    'verified',
+                    'upload_failed',
+                    'verify_failed'
+                ))
+            );
+            INSERT INTO upload_ledger (
+                evaluation_id,
+                remote_object_name,
+                local_path,
+                file_index,
+                status,
+                content_md5,
+                file_size,
+                manifest_key,
+                manifest_hash,
+                upload_start_at,
+                upload_finish_at,
+                error_type,
+                error_message,
+                created_at,
+                updated_at
+            )
+            SELECT
+                evaluation_id,
+                remote_object_name,
+                local_path,
+                file_index,
+                status,
+                content_md5,
+                file_size,
+                CASE
+                    WHEN EXISTS (
+                        SELECT 1 FROM pragma_table_info('upload_ledger_old')
+                        WHERE name = 'manifest_key'
+                    )
+                    THEN manifest_key
+                    ELSE NULL
+                END,
+                manifest_hash,
+                upload_start_at,
+                upload_finish_at,
+                error_type,
+                error_message,
+                created_at,
+                updated_at
+            FROM upload_ledger_old;
+            DROP TABLE upload_ledger_old;
+            """
+        )
+
+    def _deduplicate_file_indexes(self, conn: sqlite3.Connection) -> None:
+        # File order is no longer identity. Keep legacy duplicate indexes as
+        # diagnostics instead of mutating them for a uniqueness constraint.
+        return
+
+    def _harden_permissions(self) -> None:
+        if os.name == "nt" or not os.path.exists(self.path):
+            return
+        os.chmod(self.path, 0o600)
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(
+            self.path,
+            timeout=self.busy_timeout_ms / 1000.0,
+            isolation_level=None,
+        )
+        conn.row_factory = sqlite3.Row
+        conn.execute(f"PRAGMA busy_timeout = {self.busy_timeout_ms}")
+        conn.execute("PRAGMA foreign_keys = ON")
+        return conn
+
+    def _fetch_row(
+        self, conn: sqlite3.Connection, evaluation_id: str, remote_object_name: str
+    ) -> Optional[UploadLedgerRow]:
+        row = conn.execute(
+            """
+            SELECT * FROM upload_ledger
+            WHERE evaluation_id = ? AND remote_object_name = ?
+            """,
+            (evaluation_id, remote_object_name),
+        ).fetchone()
+        if row is None:
+            return None
+        return self._row_from_sql(row)
+
+    def _row_from_sql(self, row: sqlite3.Row) -> UploadLedgerRow:
+        return UploadLedgerRow(
+            evaluation_id=str(row["evaluation_id"]),
+            remote_object_name=str(row["remote_object_name"]),
+            local_path=str(row["local_path"]),
+            status=str(row["status"]),
+            file_index=row["file_index"],
+            content_md5=row["content_md5"],
+            file_size=row["file_size"],
+            manifest_key=row["manifest_key"],
+            manifest_hash=row["manifest_hash"],
+            upload_start_at=row["upload_start_at"],
+            upload_finish_at=row["upload_finish_at"],
+            error_type=row["error_type"],
+            error_message=row["error_message"],
+            created_at=str(row["created_at"]),
+            updated_at=str(row["updated_at"]),
+        )
+
+    def _fetch_row_by_file_index(
+        self, conn: sqlite3.Connection, evaluation_id: str, file_index: int
+    ) -> Optional[UploadLedgerRow]:
+        row = conn.execute(
+            """
+            SELECT * FROM upload_ledger
+            WHERE evaluation_id = ? AND file_index = ?
+            ORDER BY created_at
+            LIMIT 1
+            """,
+            (evaluation_id, file_index),
+        ).fetchone()
+        if row is None:
+            return None
+        return self._row_from_sql(row)
+
+    def _fetch_rows_by_manifest_key(
+        self, conn: sqlite3.Connection, evaluation_id: str, manifest_key: str
+    ) -> List[UploadLedgerRow]:
+        rows = conn.execute(
+            """
+            SELECT *
+            FROM upload_ledger
+            WHERE evaluation_id = ? AND manifest_key = ?
+            ORDER BY file_index ASC, remote_object_name ASC
+            """,
+            (evaluation_id, manifest_key),
+        ).fetchall()
+        return [self._row_from_sql(row) for row in rows]
+
+    def _finalization_column_matches(
+        self,
+        evaluation_id: str,
+        timestamp_column: str,
+        hash_column: str,
+        expected_hash: Optional[str],
+    ) -> bool:
+        if timestamp_column not in {"processed_at", "session_json_uploaded_at"}:
+            raise ValueError("unsupported finalization column")
+        if hash_column not in {"processed_request_hash", "session_json_hash"}:
+            raise ValueError("unsupported finalization hash column")
+        if not isinstance(evaluation_id, str) or not evaluation_id:
+            raise ValueError("evaluation_id must be a non-empty string")
+        if expected_hash is not None and (
+            not isinstance(expected_hash, str) or not expected_hash
+        ):
+            raise ValueError("expected_hash must be a non-empty string or None")
+        with self._connect() as conn:
+            row = conn.execute(
+                f"""
+                SELECT {timestamp_column}, {hash_column}
+                FROM upload_ledger_finalization
+                WHERE evaluation_id = ?
+                """,
+                (evaluation_id,),
+            ).fetchone()
+        if row is None or row[timestamp_column] is None:
+            return False
+        if expected_hash is None:
+            return True
+        return row[hash_column] == expected_hash
+
+    def _validate_identity(self, evaluation_id: str, remote_object_name: str) -> None:
+        if not isinstance(evaluation_id, str) or not evaluation_id:
+            raise ValueError("evaluation_id must be a non-empty string")
+        if not isinstance(remote_object_name, str) or not remote_object_name:
+            raise ValueError("remote_object_name must be a non-empty string")
+
+    def _validate_status(self, status: str) -> None:
+        if status not in LEDGER_STATUSES:
+            raise ValueError(f"Unknown upload ledger status: {status}")
+
+    def _now(self) -> str:
+        return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace(
+            "+00:00", "Z"
+        )

--- a/podonos/core/upload_manager.py
+++ b/podonos/core/upload_manager.py
@@ -3,7 +3,6 @@ import atexit
 import datetime
 import queue
 import threading
-import time
 from typing import TYPE_CHECKING
 
 from concurrent.futures import ThreadPoolExecutor
@@ -16,10 +15,17 @@ try:
 except Exception:  # pragma: no cover
     from typing_extensions import Protocol  # type: ignore
 
-from podonos.core.base import *
+from podonos.core.base import log
+from podonos.common.redaction import redact_secrets
 from podonos.service.evaluation_service import EvaluationService
 from podonos.common.util import calculate_file_md5_base64
 from podonos.common.validator import Rules, validate_args
+from podonos.errors.error import UploadBatchError, UploadFailure
+from podonos.core.upload_ledger import (
+    UploadLedger,
+    build_upload_manifest_hash,
+    build_upload_manifest_key,
+)
 
 if TYPE_CHECKING:
     from podonos.core.file import Audio
@@ -65,6 +71,12 @@ class UploadManager:
     #
     _upload_start: Optional[Dict[str, str]] = None
     _upload_finish: Optional[Dict[str, str]] = None
+    _api_timeout: Tuple[float, float] = (5, 30)
+    _upload_timeout: Tuple[float, float] = (10, 300)
+    _upload_errors: Optional[list[UploadFailure]] = None
+    _upload_errors_lock: Optional[threading.Lock] = None
+    _upload_success_lock: Optional[threading.Lock] = None
+    _upload_ledger: Optional[UploadLedger] = None
 
     def get_upload_time(self) -> Tuple[Dict[str, str], Dict[str, str]]:
         if not self._upload_start or not self._upload_finish:
@@ -80,13 +92,22 @@ class UploadManager:
         self,
         evaluation_service: EvaluationService,
         max_workers: int,
+        api_timeout: Tuple[float, float] = (5, 30),
+        upload_timeout: Tuple[float, float] = (10, 300),
+        upload_ledger: Optional[UploadLedger] = None,
     ) -> None:
         self._upload_start = dict()
         self._upload_finish = dict()
+        self._upload_errors = []
+        self._upload_errors_lock = threading.Lock()
+        self._upload_success_lock = threading.Lock()
         self._evaluation_service = evaluation_service
         self._queue = queue.Queue()
         self._total_files = 0
         self._max_workers = max_workers
+        self._api_timeout = api_timeout
+        self._upload_timeout = upload_timeout
+        self._upload_ledger = upload_ledger
         self._worker_event = Event()
         self._daemon_thread = threading.Thread(
             target=self._uploader_daemon, daemon=True
@@ -101,7 +122,7 @@ class UploadManager:
         with ThreadPoolExecutor(max_workers=self._max_workers) as executor:
             for index in range(self._max_workers):
                 executor.submit(self._upload_worker, index, self._worker_event)  # type: ignore
-        log.debug(f"Uploader daemon is shutting down")
+        log.debug("Uploader daemon is shutting down")
         executor.shutdown(wait=True)
 
     @validate_args(index=Rules.int_not_none, worker_event=Rules.instance_of(Event))
@@ -113,59 +134,85 @@ class UploadManager:
             and self._evaluation_service is not None  # type: ignore
             and self._upload_start is not None
             and self._upload_finish is not None
+            and self._upload_success_lock is not None
         ):
             raise ValueError("Upload Manager is not initialized")
 
         log.debug(f"Worker is {index} ready")
         while True:
-            if not self._queue.empty():
-                item: Tuple[str, "Audio"] = self._queue.get()
-                evaluation_id = item[0]
-                audio = item[1]
+            try:
+                item: Tuple[str, "Audio"] = self._queue.get(timeout=0.1)
+            except queue.Empty:
+                if worker_event.is_set():
+                    log.debug(f"Worker {index} is done")
+                    return
+                continue
 
-                log.debug(f"Worker {index} calculating MD5 for {audio.path}")
-                content_md5, file_size = calculate_file_md5_base64(audio.path)
-                audio.set_integrity_info(content_md5, file_size)
-                log.debug(f"Worker {index} MD5: {content_md5}, size: {file_size}")
+            evaluation_id = item[0]
+            audio = item[1]
+
+            try:
+                log.debug(f"Worker {index} calculating file integrity")
+                content_md5, file_size = self._get_or_calculate_integrity(audio)
+                self._mark_ledger_md5_ready(
+                    evaluation_id, audio, content_md5, file_size
+                )
+                log.debug(f"Worker {index} integrity calculated: size={file_size}")
 
                 log.debug(f"Worker {index} presigned url request")
                 presigned_url = self._evaluation_service.get_presigned_url(
                     evaluation_id,
                     audio.remote_object_name,
+                    timeout=self._api_timeout,
+                    context={"file_count": 1},
                 )
                 log.debug(f"Worker {index} presigned url obtained")
 
-                log.debug(f"Worker {index} uploading {audio.path}")
+                log.debug(f"Worker {index} uploading file")
                 upload_start_at = (
                     datetime.datetime.now()
                     .astimezone()
                     .isoformat(timespec="milliseconds")
                 )
                 self._evaluation_service.upload_evaluation_file(
-                    presigned_url, audio.path
+                    presigned_url,
+                    audio.path,
+                    timeout=self._upload_timeout,
+                    context={"evaluation_id": evaluation_id},
                 )
                 upload_finish_at = (
                     datetime.datetime.now()
                     .astimezone()
                     .isoformat(timespec="milliseconds")
                 )
-                log.debug(
-                    f"Worker {index} finished uploading {audio.remote_object_name}"
-                )
+                log.debug(f"Worker {index} finished uploading {audio.remote_object_name}")
 
                 audio.set_upload_at(upload_start_at, upload_finish_at)
-                self._upload_start[audio.remote_object_name] = upload_start_at
-                self._upload_finish[audio.remote_object_name] = upload_finish_at
+                self._mark_ledger_uploaded(
+                    evaluation_id, audio, upload_start_at, upload_finish_at
+                )
+                with self._upload_success_lock:
+                    self._upload_start[audio.remote_object_name] = upload_start_at
+                    self._upload_finish[audio.remote_object_name] = upload_finish_at
+                    self._total_uploaded += 1
+                    log.debug(f"Worker {index} total_uploaded: {self._total_uploaded}")
+                    if self._pbar:
+                        self._pbar.update(1)
+            except Exception as exc:
+                self._record_upload_error(evaluation_id, audio, exc)
+            finally:
                 self._queue.task_done()
-                self._total_uploaded += 1
-                log.debug(f"Worker {index} total_uploaded: {self._total_uploaded}")
-                if self._pbar:
-                    self._pbar.update(1)
 
-            time.sleep(0.1)
             if worker_event.is_set():
                 log.debug(f"Worker {index} is done")
                 return
+
+    def _get_or_calculate_integrity(self, audio: "Audio") -> tuple[str, int]:
+        if audio.content_md5 and audio.file_size and audio.file_size > 0:
+            return audio.content_md5, audio.file_size
+        content_md5, file_size = calculate_file_md5_base64(audio.path)
+        audio.set_integrity_info(content_md5, file_size)
+        return content_md5, file_size
 
     def add_file_to_queue(self, evaluation_id: str, audio: "Audio") -> None:
         if not (
@@ -175,10 +222,11 @@ class UploadManager:
             and self._evaluation_service is not None  # type: ignore
             and self._upload_start is not None
             and self._upload_finish is not None
+            and self._upload_success_lock is not None
         ):
             raise ValueError("Upload Manager is not initialized")
 
-        log.debug(f"Added: {audio.path}")
+        log.debug("Added upload queue item")
         self._queue.put((evaluation_id, audio))
         self._total_files += 1
 
@@ -207,10 +255,91 @@ class UploadManager:
         log.debug("Shutdown uploader daemon")
         self._daemon_thread.join()
 
-        self._pbar.close()
-        log.info("All upload work complete.")
         self._status = False
+        if self._pbar:
+            self._pbar.close()
+        try:
+            atexit.unregister(self.wait_and_close)
+        except Exception:
+            pass
+        if self._upload_errors:
+            log.error(f"{len(self._upload_errors)} upload(s) failed.")
+            raise UploadBatchError(self._upload_errors)
+        log.info("All upload work complete.")
         return True
+
+    def _record_upload_error(
+        self, evaluation_id: str, audio: "Audio", exc: Exception
+    ) -> None:
+        if self._upload_errors is None or self._upload_errors_lock is None:
+            raise ValueError("Upload Manager is not initialized")
+
+        failure = UploadFailure(
+            path=audio.path,
+            remote_object_name=audio.remote_object_name,
+            error_type=type(exc).__name__,
+            error_message=redact_secrets(exc),
+        )
+        with self._upload_errors_lock:
+            self._upload_errors.append(failure)
+        log.error(
+            f"Failed to upload file ({audio.remote_object_name}): "
+            f"{failure.error_type}: {failure.error_message}"
+        )
+        if self._upload_ledger is not None:
+            try:
+                self._upload_ledger.mark_upload_failed(
+                    evaluation_id,
+                    audio.remote_object_name,
+                    failure.error_type,
+                    failure.error_message,
+                )
+            except Exception as ledger_exc:
+                log.warning(
+                    f"Failed to mark upload ledger failure for "
+                    f"{audio.remote_object_name}: {redact_secrets(ledger_exc)}"
+                )
+
+    def _mark_ledger_md5_ready(
+        self, evaluation_id: str, audio: "Audio", content_md5: str, file_size: int
+    ) -> None:
+        if self._upload_ledger is None:
+            return
+        manifest_hash = build_upload_manifest_hash(
+            audio.to_create_file_dict(), content_md5, file_size
+        )
+        manifest_key = build_upload_manifest_key(
+            audio.to_create_file_dict(), content_md5, file_size
+        )
+        try:
+            self._upload_ledger.mark_md5_ready(
+                evaluation_id,
+                audio.remote_object_name,
+                content_md5,
+                file_size,
+                manifest_hash=manifest_hash,
+                manifest_key=manifest_key,
+            )
+        except Exception as exc:
+            raise RuntimeError(
+                "Failed to update upload ledger md5_ready for "
+                f"{audio.remote_object_name}: {redact_secrets(exc)}"
+            ) from exc
+
+    def _mark_ledger_uploaded(
+        self, evaluation_id: str, audio: "Audio", upload_start_at: str, upload_finish_at: str
+    ) -> None:
+        if self._upload_ledger is None:
+            return
+        try:
+            self._upload_ledger.mark_uploaded(
+                evaluation_id, audio.remote_object_name, upload_start_at, upload_finish_at
+            )
+        except Exception as exc:
+            raise RuntimeError(
+                "Failed to update upload ledger uploaded for "
+                f"{audio.remote_object_name}: {redact_secrets(exc)}"
+            ) from exc
 
     def _check_if_initialize(self) -> bool:
         return (
@@ -220,4 +349,5 @@ class UploadManager:
             and self._evaluation_service is not None  # type: ignore
             and self._upload_start is not None
             and self._upload_finish is not None
+            and self._upload_success_lock is not None
         )

--- a/podonos/errors/__init__.py
+++ b/podonos/errors/__init__.py
@@ -2,6 +2,8 @@ from podonos.errors.error import (
     FileVerificationFailure,
     InvalidFileError,
     NotSupportedError,
+    UploadBatchError,
+    UploadFailure,
     UploadRetryExhaustedError,
     UploadVerificationError,
 )
@@ -10,6 +12,8 @@ __all__ = [
     "FileVerificationFailure",
     "InvalidFileError",
     "NotSupportedError",
+    "UploadBatchError",
+    "UploadFailure",
     "UploadRetryExhaustedError",
     "UploadVerificationError",
 ]

--- a/podonos/errors/error.py
+++ b/podonos/errors/error.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from typing import List, Optional
 
+from podonos.common.redaction import redact_secrets
+
 
 class NotSupportedError(Exception):
     """Exception raised for unsupported operations."""
@@ -43,7 +45,9 @@ class UploadVerificationError(Exception):
         self.max_retries = max_retries
 
         detail_lines = [
-            f"\n  - {f.original_name}: {f.error_code} ({f.message})" for f in failures
+            f"\n  - {redact_secrets(f.original_name)}: {redact_secrets(f.error_code)} "
+            f"({redact_secrets(f.message)})"
+            for f in failures
         ]
         full_message = f"{message}{''.join(detail_lines)}"
         super().__init__(full_message)
@@ -53,3 +57,27 @@ class UploadRetryExhaustedError(UploadVerificationError):
     """Raised when max retry attempts exceeded for upload verification."""
 
     pass
+
+
+@dataclass
+class UploadFailure:
+    path: str
+    remote_object_name: str
+    error_type: str
+    error_message: str
+
+
+class UploadBatchError(Exception):
+    """Raised when one or more concurrent uploads fail."""
+
+    def __init__(self, failures: List[UploadFailure]):
+        self.failures = failures
+        detail_lines = [
+            f"\n  - upload item ({redact_secrets(failure.remote_object_name)}): "
+            f"{redact_secrets(failure.error_type)}: "
+            f"{redact_secrets(failure.error_message)}"
+            for failure in failures
+        ]
+        super().__init__(
+            f"{len(failures)} upload(s) failed:{''.join(detail_lines)}"
+        )

--- a/podonos/evaluation/human_evaluation.py
+++ b/podonos/evaluation/human_evaluation.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, Optional, Union
+import os
+from typing import Any, Dict, Optional, Tuple, Union
 
 from requests import HTTPError
 
@@ -9,6 +10,7 @@ from podonos.core.base import log
 from podonos.core.config import EvalConfig, EvalConfigDefault
 from podonos.core.evaluator import Evaluator
 from podonos.core.template import TemplateJsonLoader, TemplateValidator
+from podonos.core.upload_ledger import UploadLedger
 from podonos.service import EvaluationService, TemplateService
 
 
@@ -40,6 +42,11 @@ class HumanEvaluation:
         auto_start=Rules.bool_not_none,
         max_upload_workers=Rules.int_not_none,
         verify_batch_size=Rules.int_not_none,
+        api_timeout=Rules.make_type_rule((tuple, list)),
+        verify_timeout=Rules.make_type_rule((tuple, list)),
+        upload_timeout=Rules.make_type_rule((tuple, list)),
+        resume_upload=Rules.bool_not_none,
+        upload_state_path=Rules.str_not_none_or_none,
     )
     def create(
         self,
@@ -55,6 +62,11 @@ class HumanEvaluation:
         auto_start: bool = EvalConfigDefault.AUTO_START,
         max_upload_workers: int = EvalConfigDefault.MAX_UPLOAD_WORKERS,
         verify_batch_size: int = EvalConfigDefault.VERIFY_BATCH_SIZE,
+        api_timeout: Tuple[float, float] = EvalConfigDefault.API_TIMEOUT,
+        verify_timeout: Tuple[float, float] = EvalConfigDefault.VERIFY_TIMEOUT,
+        upload_timeout: Tuple[float, float] = EvalConfigDefault.UPLOAD_TIMEOUT,
+        resume_upload: bool = EvalConfigDefault.RESUME_UPLOAD,
+        upload_state_path: Optional[str] = EvalConfigDefault.UPLOAD_STATE_PATH,
     ) -> Evaluator:
         """Creates a new evaluator with a unique evaluation session ID.
         For the language code, see https://www.podonos.com/docs/reference#param-lan
@@ -72,6 +84,12 @@ class HumanEvaluation:
             use_loudness_normalization: Enable loudness normalization for evaluation.
             auto_start: The evaluation start automatically if True. Otherwise, manually start in the workspace.
             max_upload_workers: The maximum number of upload workers. Must be a positive integer. Default: 20
+            verify_batch_size: The batch size for file verification API calls. Must be 1-1000. Default: 100
+            api_timeout: Default API timeout tuple. Default: (5, 30)
+            verify_timeout: File verification timeout tuple. Default: (5, 120)
+            upload_timeout: Direct upload timeout tuple. Default: (10, 300)
+            resume_upload: Enable SDK-local upload ledger/resume. Default: False
+            upload_state_path: Optional SQLite ledger path when resume_upload is enabled.
 
         Returns:
             Evaluator instance.
@@ -99,6 +117,11 @@ class HumanEvaluation:
             auto_start=auto_start,
             max_upload_workers=max_upload_workers,
             verify_batch_size=verify_batch_size,
+            api_timeout=api_timeout,
+            verify_timeout=verify_timeout,
+            upload_timeout=upload_timeout,
+            resume_upload=resume_upload,
+            upload_state_path=upload_state_path,
         )
 
         if EvalType.is_double(type):
@@ -119,6 +142,171 @@ class HumanEvaluation:
         )
 
     @validate_args(
+        evaluation_id=Rules.uuid_not_none,
+        upload_state_path=Rules.str_not_none,
+        name=Rules.str_not_none_or_none,
+        desc=Rules.str_not_none_or_none,
+        type=Rules.str_not_none,
+        lan=Rules.str_not_none,
+        granularity=Rules.float_not_none,
+        num_eval=Rules.int_not_none,
+        due_hours=Rules.int_not_none,
+        use_annotation=Rules.bool_not_none,
+        use_loudness_normalization=Rules.bool_not_none,
+        auto_start=Rules.bool_not_none,
+        max_upload_workers=Rules.int_not_none,
+        verify_batch_size=Rules.int_not_none,
+        api_timeout=Rules.make_type_rule((tuple, list)),
+        verify_timeout=Rules.make_type_rule((tuple, list)),
+        upload_timeout=Rules.make_type_rule((tuple, list)),
+    )
+    def resume(
+        self,
+        evaluation_id: str,
+        upload_state_path: str,
+        name: Optional[str] = None,
+        desc: Optional[str] = None,
+        type: str = EvalConfigDefault.TYPE.value,
+        lan: str = EvalConfigDefault.LAN.value,
+        granularity: float = EvalConfigDefault.GRANULARITY,
+        num_eval: int = EvalConfigDefault.NUM_EVAL,
+        due_hours: int = EvalConfigDefault.DUE_HOURS,
+        use_annotation: bool = EvalConfigDefault.USE_ANNOTATION,
+        use_loudness_normalization: bool = EvalConfigDefault.USE_LOUDNESS_NORMALIZATION,
+        auto_start: bool = EvalConfigDefault.AUTO_START,
+        max_upload_workers: int = EvalConfigDefault.MAX_UPLOAD_WORKERS,
+        verify_batch_size: int = EvalConfigDefault.VERIFY_BATCH_SIZE,
+        api_timeout: Tuple[float, float] = EvalConfigDefault.API_TIMEOUT,
+        verify_timeout: Tuple[float, float] = EvalConfigDefault.VERIFY_TIMEOUT,
+        upload_timeout: Tuple[float, float] = EvalConfigDefault.UPLOAD_TIMEOUT,
+    ) -> Evaluator:
+        """Resume an existing evaluation using local upload ledger state."""
+
+        ledger_contract = self._load_resume_contract(
+            evaluation_id=evaluation_id,
+            upload_state_path=upload_state_path,
+        )
+        if ledger_contract is None:
+            raise ValueError(
+                "Upload ledger is missing the original evaluation contract; "
+                "cannot safely resume this evaluation."
+            )
+        contract_batch_size: Optional[int] = None
+        template_id: Optional[str] = None
+        session_config = ledger_contract.get("session_config")
+        if isinstance(session_config, dict):
+            name = session_config.get("eval_name", name)
+            desc = session_config.get("eval_description", desc)
+            num_eval = int(session_config.get("eval_num", num_eval))
+            auto_start = self._contract_bool(
+                session_config, "eval_auto_start", auto_start
+            )
+            verify_batch_size = int(
+                session_config.get("verify_batch_size", verify_batch_size)
+            )
+        type = str(ledger_contract.get("eval_type", type))
+        lan = str(ledger_contract.get("eval_language", lan))
+        use_annotation = self._contract_bool(
+            ledger_contract, "use_annotation", use_annotation
+        )
+        use_loudness_normalization = self._contract_bool(
+            ledger_contract,
+            "use_loudness_normalization",
+            use_loudness_normalization,
+        )
+        template_id_value = ledger_contract.get("eval_template_id")
+        template_id = (
+            str(template_id_value)
+            if template_id_value not in (None, "")
+            else None
+        )
+        batch_size_value = ledger_contract.get("eval_batch_size")
+        if batch_size_value is not None:
+            contract_batch_size = int(batch_size_value)
+
+        if not EvalType.is_eval_type(type):
+            raise ValueError(
+                "Not supported evaluation types. Use one of the "
+                "{'NMOS', 'QMOS', 'P808', 'CMOS', 'SMOS', 'CSMOS', 'PREF', 'CUSTOM_SINGLE', 'CUSTOM_DOUBLE', 'RANKING'}"
+            )
+
+        eval_config = EvalConfig(
+            name=name,
+            desc=desc,
+            type=type,
+            lan=lan,
+            granularity=granularity,
+            num_eval=num_eval,
+            due_hours=due_hours,
+            use_annotation=use_annotation,
+            use_loudness_normalization=use_loudness_normalization,
+            auto_start=auto_start,
+            template_id=template_id,
+            max_upload_workers=max_upload_workers,
+            verify_batch_size=verify_batch_size,
+            api_timeout=api_timeout,
+            verify_timeout=verify_timeout,
+            upload_timeout=upload_timeout,
+            resume_upload=True,
+            upload_state_path=upload_state_path,
+            resume_evaluation_id=evaluation_id,
+        )
+        if ledger_contract and isinstance(ledger_contract.get("session_config"), dict):
+            eval_config.restore_resume_session_config(ledger_contract["session_config"])
+        if contract_batch_size is not None:
+            eval_config.eval_batch_size = contract_batch_size
+
+        if EvalType.is_double(type):
+            supported_types = EvalType.get_double_types()
+        elif EvalType.is_single(type):
+            supported_types = EvalType.get_single_types()
+        elif EvalType.is_triple(type):
+            supported_types = EvalType.get_triple_types()
+        elif EvalType.is_ranking(type):
+            supported_types = EvalType.get_ranking_types()
+        else:
+            raise ValueError(f"Invalid evaluation type: {type}")
+
+        return Evaluator(
+            api_client=self._api_client,
+            eval_config=eval_config,
+            supported_eval_types=supported_types,
+        )
+
+    def _load_resume_contract(
+        self, evaluation_id: str, upload_state_path: str
+    ) -> Optional[Dict[str, Any]]:
+        """Read immutable resume contract so callers need not repeat it."""
+
+        if not os.path.isfile(os.path.abspath(upload_state_path)):
+            return None
+        ledger = UploadLedger(upload_state_path)
+        contract = ledger.get_evaluation_contract(evaluation_id)
+        if contract is None:
+            return None
+        if not isinstance(contract.get("session_config"), dict):
+            raise ValueError(
+                "Upload ledger is missing the original session configuration; "
+                "cannot safely resume this evaluation."
+            )
+        return contract
+
+    @staticmethod
+    def _contract_bool(
+        contract: Dict[str, Any],
+        key: str,
+        fallback: bool,
+    ) -> bool:
+        value = contract.get(key)
+        if value is None:
+            return fallback
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.strip().lower() in {"1", "true", "yes", "y"}
+        return bool(value)
+
+    @validate_args(
         name=Rules.str_not_none,
         template_id=Rules.str_non_empty,
         num_eval=Rules.int_not_none,
@@ -128,6 +316,11 @@ class HumanEvaluation:
         auto_start=Rules.bool_not_none,
         max_upload_workers=Rules.int_not_none,
         verify_batch_size=Rules.int_not_none,
+        api_timeout=Rules.make_type_rule((tuple, list)),
+        verify_timeout=Rules.make_type_rule((tuple, list)),
+        upload_timeout=Rules.make_type_rule((tuple, list)),
+        resume_upload=Rules.bool_not_none,
+        upload_state_path=Rules.str_not_none_or_none,
     )
     def create_from_template(
         self,
@@ -140,6 +333,11 @@ class HumanEvaluation:
         auto_start: bool = EvalConfigDefault.AUTO_START,
         max_upload_workers: int = EvalConfigDefault.MAX_UPLOAD_WORKERS,
         verify_batch_size: int = EvalConfigDefault.VERIFY_BATCH_SIZE,
+        api_timeout: Tuple[float, float] = EvalConfigDefault.API_TIMEOUT,
+        verify_timeout: Tuple[float, float] = EvalConfigDefault.VERIFY_TIMEOUT,
+        upload_timeout: Tuple[float, float] = EvalConfigDefault.UPLOAD_TIMEOUT,
+        resume_upload: bool = EvalConfigDefault.RESUME_UPLOAD,
+        upload_state_path: Optional[str] = EvalConfigDefault.UPLOAD_STATE_PATH,
     ) -> Evaluator:
         """
         Creates a new evaluator using a predefined template.
@@ -151,6 +349,12 @@ class HumanEvaluation:
             num_eval: The number of evaluators per file. Should be >= 1.
             auto_start: The evaluation start automatically if True. Otherwise, manually start in the workspace.
             max_upload_workers: The maximum number of upload workers. Must be a positive integer. Default: 20
+            verify_batch_size: The batch size for file verification API calls. Must be 1-1000. Default: 100
+            api_timeout: Default API timeout tuple. Default: (5, 30)
+            verify_timeout: File verification timeout tuple. Default: (5, 120)
+            upload_timeout: Direct upload timeout tuple. Default: (10, 300)
+            resume_upload: Enable SDK-local upload ledger/resume. Default: False
+            upload_state_path: Optional SQLite ledger path when resume_upload is enabled.
 
         Returns:
             Evaluator instance.
@@ -181,6 +385,11 @@ class HumanEvaluation:
             template_id=str(template.id),
             max_upload_workers=max_upload_workers,
             verify_batch_size=verify_batch_size,
+            api_timeout=api_timeout,
+            verify_timeout=verify_timeout,
+            upload_timeout=upload_timeout,
+            resume_upload=resume_upload,
+            upload_state_path=upload_state_path,
         )
 
         # Derive supported types from the selected type
@@ -204,6 +413,11 @@ class HumanEvaluation:
         auto_start=Rules.bool_not_none,
         max_upload_workers=Rules.int_not_none,
         verify_batch_size=Rules.int_not_none,
+        api_timeout=Rules.make_type_rule((tuple, list)),
+        verify_timeout=Rules.make_type_rule((tuple, list)),
+        upload_timeout=Rules.make_type_rule((tuple, list)),
+        resume_upload=Rules.bool_not_none,
+        upload_state_path=Rules.str_not_none_or_none,
     )
     def create_from_template_json(
         self,
@@ -219,6 +433,11 @@ class HumanEvaluation:
         auto_start: bool = EvalConfigDefault.AUTO_START,
         max_upload_workers: int = EvalConfigDefault.MAX_UPLOAD_WORKERS,
         verify_batch_size: int = EvalConfigDefault.VERIFY_BATCH_SIZE,
+        api_timeout: Tuple[float, float] = EvalConfigDefault.API_TIMEOUT,
+        verify_timeout: Tuple[float, float] = EvalConfigDefault.VERIFY_TIMEOUT,
+        upload_timeout: Tuple[float, float] = EvalConfigDefault.UPLOAD_TIMEOUT,
+        resume_upload: bool = EvalConfigDefault.RESUME_UPLOAD,
+        upload_state_path: Optional[str] = EvalConfigDefault.UPLOAD_STATE_PATH,
     ) -> Evaluator:
         """Creates a new evaluator using a template JSON.
 
@@ -234,6 +453,12 @@ class HumanEvaluation:
             use_loudness_normalization: Enable loudness normalization for evaluation. Default: False
             auto_start: The evaluation start automatically if True. Otherwise, manually start in the workspace.
             max_upload_workers: The maximum number of upload workers. Must be a positive integer. Default: 20
+            verify_batch_size: The batch size for file verification API calls. Must be 1-1000. Default: 100
+            api_timeout: Default API timeout tuple. Default: (5, 30)
+            verify_timeout: File verification timeout tuple. Default: (5, 120)
+            upload_timeout: Direct upload timeout tuple. Default: (10, 300)
+            resume_upload: Enable SDK-local upload ledger/resume. Default: False
+            upload_state_path: Optional SQLite ledger path when resume_upload is enabled.
 
         Returns:
             Evaluator instance.
@@ -299,6 +524,11 @@ class HumanEvaluation:
             auto_start=auto_start,
             max_upload_workers=max_upload_workers,
             verify_batch_size=verify_batch_size,
+            api_timeout=api_timeout,
+            verify_timeout=verify_timeout,
+            upload_timeout=upload_timeout,
+            resume_upload=resume_upload,
+            upload_state_path=upload_state_path,
             skip_default_questions=True,
         )
         log.info(f"Created evaluation config with type: {eval_type.value}")

--- a/podonos/service/evaluation_service.py
+++ b/podonos/service/evaluation_service.py
@@ -1,21 +1,29 @@
 import hashlib
 import json
 import os
-from typing import Any, Dict, List, Literal, Optional
+import re
+from typing import Any, Dict, List, Literal, Optional, Tuple
+from urllib.parse import urlparse
 
 from requests import Response
 from tqdm import tqdm
 
 from podonos.common.constant import CONTENT_TYPE_TO_EXTENSION
 from podonos.common.exception import HTTPError
+from podonos.common.redaction import redact_secrets
 from podonos.common.util import get_content_type_by_filename
 from podonos.common.validator import Rules, validate_args
 from podonos.core.api import APIClient
 from podonos.core.base import log
-from podonos.core.config import EvalConfig
+from podonos.core.config import EvalConfig, EvalConfigDefault
 from podonos.core.file import Audio, AudioGroup
 from podonos.entity.evaluation import EvaluationEntity
 from podonos.entity.verification import ProcessFilesResponse, VerifyFilesResponse
+
+
+_TRUTHY = {"1", "true", "yes", "y", "on"}
+_PODONOS_DOWNLOAD_HOST_SUFFIXES = (".podonos.com", ".podonosapi.com")
+_PODONOS_DOWNLOAD_EXACT_HOSTS = {"podonos.com", "podonosapi.com"}
 
 
 class EvaluationService:
@@ -25,13 +33,28 @@ class EvaluationService:
         self.api_client = api_client
 
     @validate_args(evaluation_id=Rules.uuid_not_none, payload=Rules.dict_not_none)
-    def update_specific_fields(self, evaluation_id: str, payload: Dict[str, Any]) -> None:
+    def update_specific_fields(
+        self,
+        evaluation_id: str,
+        payload: Dict[str, Any],
+        timeout: Optional[Tuple[float, float]] = None,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> None:
         """
         Patch specific fields of an evaluation (e.g., batch_size) without recreating it.
         Intended for late adjustments like updating RANKING batch_size.
         """
         try:
-            response = self.api_client.patch(f"evaluations/{evaluation_id}/specific-fields", data=payload)
+            endpoint = f"evaluations/{evaluation_id}/specific-fields"
+            kwargs: Dict[str, Any] = {"data": payload}
+            if timeout is not None:
+                kwargs["timeout"] = timeout
+            if context is not None:
+                request_context = dict(context)
+                request_context["endpoint"] = endpoint
+                request_context["evaluation_id"] = evaluation_id
+                kwargs["context"] = request_context
+            response = self.api_client.patch(endpoint, **kwargs)
             response.raise_for_status()
         except Exception as e:
             raise HTTPError(
@@ -52,7 +75,12 @@ class EvaluationService:
         """
         log.debug("Create evaluation")
         try:
-            response = self.api_client.post("evaluations", data=config.to_create_request_dto())
+            response = self.api_client.post(
+                "evaluations",
+                data=config.to_create_request_dto(),
+                timeout=config.api_timeout,
+                context={"endpoint": "evaluations"},
+            )
             response.raise_for_status()
             evaluation = EvaluationEntity.from_dict(response.json())
             log.info(f"Evaluation is generated: {evaluation.id}")
@@ -76,6 +104,8 @@ class EvaluationService:
             response = self.api_client.post(
                 "evaluations/templates",
                 data=config.to_create_from_template_request_dto(),
+                timeout=config.api_timeout,
+                context={"endpoint": "evaluations/templates"},
             )
             response.raise_for_status()
             evaluation = EvaluationEntity.from_dict(response.json())
@@ -85,10 +115,24 @@ class EvaluationService:
             raise HTTPError(f"Failed to create the evaluation: {e}")
 
     @validate_args(evaluation_id=Rules.uuid_not_none)
-    def get_evaluation(self, evaluation_id: str) -> EvaluationEntity:
+    def get_evaluation(
+        self,
+        evaluation_id: str,
+        timeout: Optional[Tuple[float, float]] = None,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> EvaluationEntity:
         """Get evaluation by ID"""
         try:
-            response = self.api_client.get(f"evaluations/{evaluation_id}")
+            endpoint = f"evaluations/{evaluation_id}"
+            kwargs: Dict[str, Any] = {}
+            if timeout is not None:
+                kwargs["timeout"] = timeout
+            if context is not None:
+                request_context = dict(context)
+                request_context["endpoint"] = endpoint
+                request_context["evaluation_id"] = evaluation_id
+                kwargs["context"] = request_context
+            response = self.api_client.get(endpoint, **kwargs)
             response.raise_for_status()
             return EvaluationEntity.from_dict(response.json())
         except Exception as e:
@@ -137,11 +181,25 @@ class EvaluationService:
             raise HTTPError(f"Failed to get evaluation stats: {e}")
 
     @validate_args(evaluation_id=Rules.uuid_not_none, audios=Rules.list_not_none)
-    def create_evaluation_files(self, evaluation_id: str, audios: List[Audio]):
+    def create_evaluation_files(
+        self,
+        evaluation_id: str,
+        audios: List[Audio],
+        timeout: Tuple[float, float] = EvalConfigDefault.API_TIMEOUT,
+        context: Optional[Dict[str, Any]] = None,
+    ):
         try:
+            endpoint = f"evaluations/{evaluation_id}/files"
             response = self.api_client.put(
-                f"evaluations/{evaluation_id}/files",
+                endpoint,
                 {"files": [audio.to_create_file_dict() for audio in audios]},
+                timeout=timeout,
+                context={
+                    "endpoint": endpoint,
+                    "evaluation_id": evaluation_id,
+                    "file_count": len(audios),
+                    **(context or {}),
+                },
             )
             response.raise_for_status()
         except Exception as e:
@@ -152,33 +210,64 @@ class EvaluationService:
             )
 
     @validate_args(evaluation_id=Rules.uuid_not_none, remote_object_name=Rules.str_not_none)
-    def get_presigned_url(self, evaluation_id: str, remote_object_name: str) -> str:
+    def get_presigned_url(
+        self,
+        evaluation_id: str,
+        remote_object_name: str,
+        timeout: Tuple[float, float] = EvalConfigDefault.API_TIMEOUT,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> str:
         """Get presigned URL for file upload"""
         try:
+            endpoint = f"evaluations/{evaluation_id}/uploading-presigned-url"
             response = self.api_client.put(
-                f"evaluations/{evaluation_id}/uploading-presigned-url",
+                endpoint,
                 data={"uploaded_file_name": remote_object_name},
+                timeout=timeout,
+                context={
+                    "endpoint": endpoint,
+                    "evaluation_id": evaluation_id,
+                    "file_count": 1,
+                    **(context or {}),
+                },
             )
             response.raise_for_status()
             return response.text.replace('"', "")
         except Exception as e:
-            log.error(f"HTTP error in getting a presigned url: {e}")
-            raise HTTPError(f"Failed to get presigned URL: {e}")
+            log.error(
+                f"HTTP error in getting a presigned url: {redact_secrets(e)}"
+            )
+            raise HTTPError(f"Failed to get presigned URL: {redact_secrets(e)}")
 
     @validate_args(url=Rules.str_not_none, path=Rules.file_path_not_none)
-    def upload_evaluation_file(self, url: str, path: str) -> Response:
+    def upload_evaluation_file(
+        self,
+        url: str,
+        path: str,
+        timeout: Tuple[float, float] = EvalConfigDefault.UPLOAD_TIMEOUT,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> Response:
         try:
             with open(path, "rb") as file:
                 response = self.api_client.external_put(
                     url,
                     data=file,
                     headers={"Content-Type": get_content_type_by_filename(path)},
+                    timeout=timeout,
+                    context={
+                        "file_count": 1,
+                        **(context or {}),
+                    },
                 )
+            response.raise_for_status()
             return response
         except Exception as e:
-            log.error(f"HTTP error in uploading a file to presigned URL: {e}")
+            log.error(
+                "HTTP error in uploading a file to presigned URL: "
+                f"{redact_secrets(e)}"
+            )
             raise HTTPError(
-                f"Failed to Upload File {path}: {e}",
+                f"Failed to Upload File: {redact_secrets(e)}",
                 status_code=getattr(getattr(e, "response", None), "status_code", None),
             )
 
@@ -192,38 +281,78 @@ class EvaluationService:
         try:
             session_json = config.to_dict()
             session_json["files"] = [group.to_dict() for group in audio_groups]
-            presigned_url = self.get_presigned_url(evaluation_id, "session.json")
+            session_summary = self._session_json_summary(session_json)
+            presigned_url = self.get_presigned_url(
+                evaluation_id,
+                "session.json",
+                timeout=config.api_timeout,
+                context=session_summary,
+            )
             self.put_session_json(
                 presigned_url,
                 session_json,
                 headers={"Content-type": "application/json"},
+                timeout=config.upload_timeout,
+                context={"evaluation_id": evaluation_id, **session_summary},
             )
         except Exception as e:
-            raise HTTPError(f"Failed to upload session JSON: {e}")
+            raise HTTPError(f"Failed to upload session JSON: {redact_secrets(e)}")
 
     @validate_args(
         url=Rules.str_not_none,
         data=Rules.dict_not_none,
         headers=Rules.dict_not_none_or_none,
+        timeout=Rules.make_type_rule((tuple, list)),
+        context=Rules.dict_not_none_or_none,
     )
-    def put_session_json(self, url: str, data: Dict[str, Any], headers: Optional[Dict[str, str]] = None) -> Response:
-        log.debug("JSON data")
-        for key, value in data.items():
-            log.debug(f"{key}: {value}")
+    def put_session_json(
+        self,
+        url: str,
+        data: Dict[str, Any],
+        headers: Optional[Dict[str, str]] = None,
+        timeout: Tuple[float, float] = EvalConfigDefault.UPLOAD_TIMEOUT,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> Response:
+        log.debug(f"Session JSON summary: {self._session_json_summary(data)}")
         if headers:
-            log.debug("Headers")
-            for key, value in headers.items():
-                log.debug(f"{key}: {value}")
+            log.debug(f"Session JSON header keys: {sorted(headers.keys())}")
 
         try:
-            response = self.api_client.external_put(url, json_data=data, headers=headers)
+            response = self.api_client.external_put(
+                url,
+                json_data=data,
+                headers=headers,
+                timeout=timeout,
+                context=context,
+            )
+            response.raise_for_status()
             return response
         except Exception as e:
-            log.error(f"HTTP error in uploading a json to presigned url: {e}")
+            log.error(
+                "HTTP error in uploading a json to presigned url: "
+                f"{redact_secrets(e)}"
+            )
             raise HTTPError(
-                f"Failed to Upload JSON {data}: {e}",
+                "Failed to Upload JSON payload "
+                f"({self._session_json_summary(data)}): {redact_secrets(e)}",
                 status_code=getattr(getattr(e, "response", None), "status_code", None),
             )
+
+    def _session_json_summary(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        """Return non-sensitive shape information for session JSON diagnostics."""
+        files = data.get("files")
+        file_group_count = len(files) if isinstance(files, list) else 0
+        audio_count = 0
+        if isinstance(files, list):
+            for group in files:
+                if isinstance(group, dict) and isinstance(group.get("audios"), list):
+                    audio_count += len(group["audios"])
+
+        return {
+            "top_level_keys": sorted(str(key) for key in data.keys()),
+            "file_group_count": file_group_count,
+            "audio_count": audio_count,
+        }
 
     @validate_args(evaluation_id=Rules.uuid_not_none, output_dir=Rules.str_not_none)
     def download_evaluation_files_by_evaluation_id(self, evaluation_id: str, output_dir: str) -> str:
@@ -244,7 +373,22 @@ class EvaluationService:
             # Download each file using the original URL and cookies
             for file in tqdm(download_response["files"], desc="Downloading files", unit="file"):
                 # Download the file using the original URL and cookies
-                file_response = self.api_client.external_get(file["original_url"], cookies=download_response["cookie"])
+                original_url = self._validate_download_original_url(
+                    file["original_url"]
+                )
+                file_response = self.api_client.external_get(
+                    original_url,
+                    cookies=download_response["cookie"],
+                    allow_redirects=False,
+                )
+                status_code = getattr(file_response, "status_code", None)
+                if status_code is None or not 200 <= status_code < 300:
+                    raise HTTPError(
+                        "Download returned non-success status code "
+                        f"{status_code}",
+                        status_code=status_code,
+                        response=file_response,
+                    )
                 file_response.raise_for_status()
 
                 content_type = file_response.headers.get("Content-Type")
@@ -255,16 +399,17 @@ class EvaluationService:
                 hash_object = hashlib.md5(file_original_name.encode(), usedforsecurity=False)
                 hashed_file_name = hash_object.hexdigest()
 
-                # Construct the file path using the model tag and hashed file name
-                file_name = f"{file['model_tag']}/{hashed_file_name}{file_extension}"
-                file_path = os.path.join(output_dir, file_name)
+                # Construct the file path using a sanitized model tag.
+                safe_model_tag = self._safe_download_path_segment(
+                    file.get("model_tag", "untagged")
+                )
+                file_path = self._safe_output_path(
+                    output_dir,
+                    safe_model_tag,
+                    f"{hashed_file_name}{file_extension}",
+                )
 
-                # Ensure the directory for the model tag exists
-                os.makedirs(os.path.dirname(file_path), exist_ok=True)
-
-                # Save the file locally
-                with open(file_path, "wb") as f:
-                    f.write(file_response.content)
+                self._write_download_file(file_path, file_response.content, output_dir)
 
                 file_mata_json["files"].append(
                     {
@@ -279,16 +424,145 @@ class EvaluationService:
 
             # Save the file metadata to a JSON file
             metadata_file_path = os.path.join(output_dir, "metadata.json")
-            with open(metadata_file_path, "w") as f:
-                json.dump(file_mata_json, f)
+            self._write_download_file(
+                metadata_file_path,
+                json.dumps(file_mata_json).encode("utf-8"),
+                output_dir,
+            )
             log.info(f"File metadata saved to {metadata_file_path}")
 
             return "Files downloaded successfully."
         except Exception as e:
-            raise HTTPError(f"Failed to download evaluation files: {e}")
+            raise HTTPError(
+                f"Failed to download evaluation files: {redact_secrets(e)}"
+            )
+
+    def _validate_download_original_url(self, url: str) -> str:
+        parsed = urlparse(url)
+        host = (parsed.hostname or "").lower()
+        if parsed.scheme.lower() != "https" or not host:
+            raise ValueError("download original_url must be an HTTPS URL")
+
+        if not self._is_allowed_download_host(host):
+            raise ValueError("download original_url host is not allowed")
+        return url
+
+    def _is_allowed_download_host(self, host: str) -> bool:
+        if os.getenv("PODONOS_ALLOW_UNTRUSTED_DOWNLOAD_HOSTS", "").lower() in _TRUTHY:
+            return True
+
+        configured_hosts = {
+            item.strip().lower()
+            for item in os.getenv("PODONOS_DOWNLOAD_ALLOWED_HOSTS", "").split(",")
+            if item.strip()
+        }
+        if host in configured_hosts:
+            return True
+
+        return host in _PODONOS_DOWNLOAD_EXACT_HOSTS or host.endswith(
+            _PODONOS_DOWNLOAD_HOST_SUFFIXES
+        )
+
+    def _safe_download_path_segment(self, value: Any) -> str:
+        text = str(value or "untagged").replace("\\", "/")
+        text = "_".join(part for part in text.split("/") if part not in {"", ".", ".."})
+        text = re.sub(r"[^A-Za-z0-9._-]+", "_", text).strip("._")
+        return text or "untagged"
+
+    def _safe_output_path(self, output_dir: str, *parts: str) -> str:
+        output_root = os.path.abspath(output_dir)
+        candidate = os.path.abspath(os.path.join(output_root, *parts))
+        if os.path.commonpath([output_root, candidate]) != output_root:
+            raise ValueError("Downloaded file path escapes output_dir")
+        return candidate
+
+    def _open_safe_download_file(self, file_path: str, output_dir: str) -> int:
+        if os.name == "nt":
+            parent = os.path.dirname(file_path)
+            self._reject_symlink_components(output_dir, parent)
+            os.makedirs(parent, exist_ok=True)
+            self._reject_symlink_components(output_dir, parent)
+            if os.path.islink(file_path):
+                raise ValueError("download target file must not be a symlink")
+            return os.open(file_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+
+        output_root = os.path.abspath(output_dir)
+        candidate = os.path.abspath(file_path)
+        if os.path.commonpath([output_root, candidate]) != output_root:
+            raise ValueError("Downloaded file path escapes output_dir")
+
+        os.makedirs(output_root, exist_ok=True)
+        dir_flags = os.O_RDONLY
+        if hasattr(os, "O_DIRECTORY"):
+            dir_flags |= os.O_DIRECTORY
+        if hasattr(os, "O_NOFOLLOW"):
+            dir_flags |= os.O_NOFOLLOW
+
+        file_name = os.path.basename(candidate)
+        if file_name in {"", ".", ".."}:
+            raise ValueError("download target file name is invalid")
+        parent = os.path.dirname(candidate)
+        rel_parent = os.path.relpath(parent, output_root)
+        rel_parts = [] if rel_parent == "." else rel_parent.split(os.sep)
+
+        dir_fds: List[int] = []
+        try:
+            current_fd = os.open(output_root, dir_flags)
+            dir_fds.append(current_fd)
+            for part in rel_parts:
+                if part in {"", ".", ".."}:
+                    raise ValueError("download target path component is invalid")
+                try:
+                    os.mkdir(part, 0o700, dir_fd=current_fd)
+                except FileExistsError:
+                    pass
+                current_fd = os.open(part, dir_flags, dir_fd=current_fd)
+                dir_fds.append(current_fd)
+
+            file_flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+            if hasattr(os, "O_NOFOLLOW"):
+                file_flags |= os.O_NOFOLLOW
+            return os.open(file_name, file_flags, 0o600, dir_fd=dir_fds[-1])
+        except OSError as exc:
+            raise ValueError("download target file path is not safe to write") from exc
+        finally:
+            for fd in reversed(dir_fds):
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+
+    def _reject_symlink_components(self, output_dir: str, target_dir: str) -> None:
+        output_root = os.path.abspath(output_dir)
+        target_dir = os.path.abspath(target_dir)
+        if os.path.commonpath([output_root, target_dir]) != output_root:
+            raise ValueError("Downloaded file path escapes output_dir")
+        current = output_root
+        paths_to_check = [current]
+        rel_dir = os.path.relpath(target_dir, output_root)
+        if rel_dir != ".":
+            for part in rel_dir.split(os.sep):
+                if part in {"", ".", ".."}:
+                    raise ValueError("download target path component is invalid")
+                current = os.path.join(current, part)
+                paths_to_check.append(current)
+        for path in paths_to_check:
+            if os.path.exists(path) and os.path.islink(path):
+                raise ValueError("download target path must not contain symlinks")
+
+    def _write_download_file(self, file_path: str, content: bytes, output_dir: str) -> None:
+        fd = self._open_safe_download_file(file_path, output_dir)
+        with os.fdopen(fd, "wb") as f:
+            f.write(content)
 
     @validate_args(evaluation_id=Rules.uuid_not_none, audios=Rules.list_not_none)
-    def verify_files(self, evaluation_id: str, audios: List[Audio]) -> VerifyFilesResponse:
+    def verify_files(
+        self,
+        evaluation_id: str,
+        audios: List[Audio],
+        timeout: Tuple[float, float] = EvalConfigDefault.VERIFY_TIMEOUT,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> VerifyFilesResponse:
         try:
             payload = {
                 "files": [
@@ -300,7 +574,19 @@ class EvaluationService:
                     for audio in audios
                 ]
             }
-            response = self.api_client.post(f"evaluations/{evaluation_id}/files/verify", data=payload)
+            endpoint = f"evaluations/{evaluation_id}/files/verify"
+            response = self.api_client.post(
+                endpoint,
+                data=payload,
+                timeout=timeout,
+                context={
+                    "method": "POST",
+                    "endpoint": endpoint,
+                    "evaluation_id": evaluation_id,
+                    "file_count": len(audios),
+                    **(context or {}),
+                },
+            )
             response.raise_for_status()
             return VerifyFilesResponse.from_dict(response.json())
         except Exception as e:
@@ -310,10 +596,27 @@ class EvaluationService:
             )
 
     @validate_args(evaluation_id=Rules.uuid_not_none, file_meta_ids=Rules.list_not_none_or_none)
-    def process_files(self, evaluation_id: str, file_meta_ids: Optional[List[str]] = None) -> ProcessFilesResponse:
+    def process_files(
+        self,
+        evaluation_id: str,
+        file_meta_ids: Optional[List[str]] = None,
+        timeout: Tuple[float, float] = EvalConfigDefault.API_TIMEOUT,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> ProcessFilesResponse:
         try:
             payload: Dict[str, Any] = {"file_meta_ids": file_meta_ids} if file_meta_ids else {}
-            response = self.api_client.post(f"evaluations/{evaluation_id}/files/process", data=payload)
+            endpoint = f"evaluations/{evaluation_id}/files/process"
+            response = self.api_client.post(
+                endpoint,
+                data=payload,
+                timeout=timeout,
+                context={
+                    "endpoint": endpoint,
+                    "evaluation_id": evaluation_id,
+                    "file_count": len(file_meta_ids or []),
+                    **(context or {}),
+                },
+            )
             response.raise_for_status()
             return ProcessFilesResponse.from_dict(response.json())
         except Exception as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ dependencies = [
     "filetype",
     "glog",
     "packaging",
-    "requests",
+    "requests>=2.33.0,<3",
+    "urllib3>=2.7.0,<3",
     "soundfile==0.12.1",
     "tqdm",
     "typing_extensions>=4.0.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,5 +46,5 @@ tomli==2.0.1
 tqdm==4.67.1
 twine==5.1.0
 typing_extensions==4.12.1
-urllib3>=2.6.3,<3
+urllib3>=2.7.0,<3
 zipp==3.19.2

--- a/tests/common/test_redaction.py
+++ b/tests/common/test_redaction.py
@@ -1,0 +1,57 @@
+import unittest
+
+from podonos.common.redaction import redact_secrets
+
+
+class TestRedaction(unittest.TestCase):
+    def test_redacts_quoted_dict_secret_fields(self):
+        message = "headers={'X-API-KEY': 'SECRET', 'Authorization': 'Bearer TOKEN'}"
+
+        redacted = redact_secrets(message)
+
+        self.assertNotIn("SECRET", redacted)
+        self.assertNotIn("TOKEN", redacted)
+        self.assertIn("[REDACTED]", redacted)
+
+    def test_redacts_cloudfront_cookie_fields(self):
+        message = (
+            "cookies={'CloudFront-Signature': 'SIGNATURE', "
+            "'CloudFront-Policy': 'POLICY', "
+            "'CloudFront-Key-Pair-Id': 'KEYPAIR'} "
+            "Cookie: session=SECRET Set-Cookie: auth=TOKEN"
+        )
+
+        redacted = redact_secrets(message)
+
+        self.assertNotIn("SIGNATURE", redacted)
+        self.assertNotIn("POLICY", redacted)
+        self.assertNotIn("KEYPAIR", redacted)
+        self.assertNotIn("session=SECRET", redacted)
+        self.assertNotIn("auth=TOKEN", redacted)
+        self.assertIn("[REDACTED]", redacted)
+
+    def test_redacts_common_secret_fields(self):
+        message = (
+            "password=hunter2 client_secret=CLIENTSECRET "
+            "refresh_token=REFRESH secret_key=SECRETKEY "
+            "payload={'private_key': 'PRIVATE', 'id_token': 'IDTOKEN'} "
+            "https://example.com/callback?client_secret=QUERYSECRET"
+        )
+
+        redacted = redact_secrets(message)
+
+        for secret in [
+            "hunter2",
+            "CLIENTSECRET",
+            "REFRESH",
+            "SECRETKEY",
+            "PRIVATE",
+            "IDTOKEN",
+            "QUERYSECRET",
+        ]:
+            self.assertNotIn(secret, redacted)
+        self.assertIn("[REDACTED]", redacted)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -87,6 +87,7 @@ class TestAPIClient(unittest.TestCase):
             self.client.initialize()
 
         self.assertIn("Invalid API key", str(context.exception))
+        self.assertNotIn(self.api_key, str(context.exception))
         mock_patch.assert_called_once_with("api-keys/last-used-time", headers=self.client._headers, data={})  # type: ignore
 
     def test_add_headers(self):
@@ -134,7 +135,14 @@ class TestAPIClient(unittest.TestCase):
 
         response = self.client.external_get(url, params=params, headers=headers, cookies=cookies)
         self.assertEqual(response.status_code, 200)
-        mock_get.assert_called_once_with(url, headers=headers, params=params, cookies=cookies, timeout=(10, 60))
+        mock_get.assert_called_once_with(
+            url,
+            headers=headers,
+            params=params,
+            cookies=cookies,
+            timeout=(10, 60),
+            allow_redirects=True,
+        )
 
     @patch("requests.put")
     def test_external_put_with_data_success(self, mock_put: Mock):
@@ -209,7 +217,14 @@ class TestAPIClient(unittest.TestCase):
         response = self.client.external_get(url)
         self.assertEqual(response.status_code, 200)
         # Should use empty dict for headers when none provided
-        mock_get.assert_called_once_with(url, headers={}, params=None, cookies=None, timeout=(10, 60))
+        mock_get.assert_called_once_with(
+            url,
+            headers={},
+            params=None,
+            cookies=None,
+            timeout=(10, 60),
+            allow_redirects=True,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/core/test_api_retry_logging.py
+++ b/tests/core/test_api_retry_logging.py
@@ -1,0 +1,211 @@
+import io
+import math
+import unittest
+from unittest.mock import Mock, patch
+
+import requests
+from requests import Response
+
+from podonos.core.api import APIClient
+
+
+class TestAPIClientRetryLogging(unittest.TestCase):
+    def setUp(self):
+        self.client = APIClient(
+            "test_api_key",
+            "https://api.example.com",
+            max_retries=1,
+            retry_delay=0,
+            backoff_factor=1,
+        )
+
+    @patch("time.sleep")
+    @patch("podonos.core.api.log.warning")
+    @patch("requests.post")
+    def test_retry_log_includes_safe_context(self, mock_post: Mock, mock_warning: Mock, mock_sleep: Mock):
+        response = Response()
+        response.status_code = 200
+        response._content = b"{}"
+        mock_post.side_effect = [
+            requests.exceptions.ReadTimeout("read timeout"),
+            response,
+        ]
+
+        self.client.post(
+            "evaluations/eval-id/files/verify",
+            data={"files": []},
+            timeout=(5, 120),
+            context={
+                "evaluation_id": "eval-id",
+                "batch_index": 3,
+                "batch_size": 100,
+                "file_count": 100,
+            },
+        )
+
+        log_message = mock_warning.call_args.args[0]
+        self.assertIn("method=POST", log_message)
+        self.assertIn("endpoint=evaluations/eval-id/files/verify", log_message)
+        self.assertIn("timeout=(5, 120)", log_message)
+        self.assertIn("batch_index=3", log_message)
+        self.assertIn("batch_size=100", log_message)
+        self.assertIn("file_count=100", log_message)
+
+    @patch("time.sleep")
+    @patch("podonos.core.api.log.warning")
+    @patch("requests.put")
+    def test_external_put_retry_log_redacts_presigned_url_and_secrets(
+        self, mock_put: Mock, mock_warning: Mock, mock_sleep: Mock
+    ):
+        response = Response()
+        response.status_code = 200
+        response._content = b""
+        raw_url = (
+            "https://bucket.s3.amazonaws.com/file.wav"
+            "?X-Amz-Signature=SECRET&X-Amz-Credential=CREDENTIAL"
+        )
+        mock_put.side_effect = [
+            requests.exceptions.ReadTimeout(f"read timeout for {raw_url} X-API-KEY=SECRET"),
+            response,
+        ]
+
+        self.client.external_put(
+            raw_url,
+            data=b"audio",
+            timeout=(10, 300),
+            context={"evaluation_id": "eval-id"},
+        )
+
+        log_message = mock_warning.call_args.args[0]
+        self.assertIn("external_endpoint=presigned_put", log_message)
+        self.assertIn("timeout=(10, 300)", log_message)
+        self.assertIn("evaluation_id=eval-id", log_message)
+        self.assertNotIn("X-Amz-Signature=SECRET", log_message)
+        self.assertNotIn("X-Amz-Credential=CREDENTIAL", log_message)
+        self.assertNotIn("X-API-KEY=SECRET", log_message)
+        self.assertNotIn(raw_url, log_message)
+
+    @patch("time.sleep")
+    @patch("requests.put")
+    def test_external_put_rewinds_file_like_data_between_retries(
+        self, mock_put: Mock, mock_sleep: Mock
+    ):
+        bodies = []
+
+        def put_side_effect(*args, **kwargs):
+            bodies.append(kwargs["data"].read())
+            response = Response()
+            response.status_code = 500 if len(bodies) == 1 else 200
+            response._content = b""
+            return response
+
+        mock_put.side_effect = put_side_effect
+        payload = io.BytesIO(b"full audio payload")
+
+        response = self.client.external_put(
+            "https://bucket.s3.amazonaws.com/file.wav",
+            data=payload,
+            timeout=(10, 300),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(bodies, [b"full audio payload", b"full audio payload"])
+
+    def test_rejects_invalid_public_timeout_values(self):
+        invalid_timeouts = [
+            5,
+            (0, 30),
+            (5, -1),
+            ("5", 30),
+            (True, 30),
+            (5,),
+            (math.nan, 30),
+            (5, math.inf),
+        ]
+
+        for timeout in invalid_timeouts:
+            with self.subTest(timeout=timeout):
+                with self.assertRaises(ValueError):
+                    self.client.get("version/sdk", timeout=timeout)  # type: ignore[arg-type]
+
+        with self.assertRaises(ValueError):
+            self.client.external_put(
+                "https://bucket.s3.amazonaws.com/file.wav",
+                data=b"audio",
+                timeout=(10, 0),
+            )
+
+    def test_sanitize_log_message_redacts_authorization_bearer_value(self):
+        message = self.client._sanitize_log_message(  # type: ignore[attr-defined]
+            "Authorization: Bearer SECRET_TOKEN"
+        )
+
+        self.assertNotIn("SECRET_TOKEN", message)
+        self.assertIn("[REDACTED]", message)
+
+    @patch("time.sleep")
+    @patch("podonos.core.api.log.warning")
+    @patch("requests.get")
+    def test_retry_context_values_are_redacted(
+        self, mock_get: Mock, mock_warning: Mock, mock_sleep: Mock
+    ):
+        response = Response()
+        response.status_code = 200
+        response._content = b"{}"
+        mock_get.side_effect = [
+            requests.exceptions.ReadTimeout("temporary timeout"),
+            response,
+        ]
+
+        self.client.get(
+            "evaluations/eval-id",
+            context={
+                "evaluation_id": "eval-id X-API-KEY=SECRET",
+                "file_count": "Authorization: Bearer TOKEN",
+            },
+        )
+
+        log_message = mock_warning.call_args.args[0]
+        self.assertNotIn("SECRET", log_message)
+        self.assertNotIn("TOKEN", log_message)
+        self.assertIn("[REDACTED]", log_message)
+
+    @patch("time.sleep")
+    @patch("podonos.core.api.log.warning")
+    @patch("requests.post")
+    def test_caller_context_cannot_override_reserved_retry_keys(
+        self, mock_post: Mock, mock_warning: Mock, mock_sleep: Mock
+    ):
+        response = Response()
+        response.status_code = 200
+        response._content = b"{}"
+        mock_post.side_effect = [
+            requests.exceptions.ReadTimeout("temporary timeout"),
+            response,
+        ]
+
+        self.client.post(
+            "evaluations/safe-endpoint",
+            data={},
+            timeout=(5, 30),
+            context={
+                "method": "LEAKY",
+                "endpoint": (
+                    "https://bucket.s3.amazonaws.com/file.wav"
+                    "?X-Amz-Signature=SECRET"
+                ),
+                "timeout": "Authorization: Bearer TOKEN",
+            },
+        )
+
+        log_message = mock_warning.call_args.args[0]
+        self.assertIn("method=POST", log_message)
+        self.assertIn("endpoint=evaluations/safe-endpoint", log_message)
+        self.assertIn("timeout=(5, 30)", log_message)
+        self.assertNotIn("LEAKY", log_message)
+        self.assertNotIn("SECRET", log_message)
+        self.assertNotIn("TOKEN", log_message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/core/test_client.py
+++ b/tests/core/test_client.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 from unittest import mock
 from unittest.mock import MagicMock, Mock, patch
@@ -11,11 +12,13 @@ from uuid import uuid4
 from requests import Response
 
 import podonos
-from podonos.common.enum import EvalType
+from podonos.common.enum import EvalType, QuestionFileType
+from podonos.common.util import calculate_file_md5_base64
 from podonos.core.api import APIClient
 from podonos.core.client import Client
 from podonos.core.evaluator import Evaluator
-from podonos.core.file import File
+from podonos.core.file import Audio, File
+from podonos.core.upload_ledger import UploadLedger, build_upload_manifest_hash
 
 
 def _make_response(
@@ -31,6 +34,45 @@ def _make_response(
     else:
         resp._content = b""
     return resp
+
+
+def _resume_contract(
+    evaluation_id: str,
+    *,
+    eval_type: str = "NMOS",
+    eval_batch_size: int = 1,
+    eval_template_id: str | None = None,
+    use_annotation: bool = False,
+    use_loudness_normalization: bool = True,
+    session_overrides: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    session_config: dict[str, Any] = {
+        "eval_name": "original-evaluation",
+        "eval_description": "original description",
+        "eval_type": eval_type,
+        "eval_language": "en-us",
+        "eval_num": 10,
+        "eval_expected_due": "2026-05-22T00:00:00.000+00:00",
+        "eval_creation_timestamp": "2026-05-21T00:00:00.000",
+        "eval_use_annotation": use_annotation,
+        "eval_auto_start": False,
+        "eval_template_id": eval_template_id,
+        "use_loudness_normalization": use_loudness_normalization,
+        "max_upload_workers": 20,
+        "verify_batch_size": 100,
+    }
+    if session_overrides:
+        session_config.update(session_overrides)
+    return {
+        "evaluation_id": evaluation_id,
+        "eval_type": eval_type,
+        "eval_language": "en-us",
+        "eval_batch_size": eval_batch_size,
+        "eval_template_id": eval_template_id,
+        "use_annotation": use_annotation,
+        "use_loudness_normalization": use_loudness_normalization,
+        "session_config": session_config,
+    }
 
 
 def mocked_requests_post(*args: Any, **kwargs: Any):
@@ -528,6 +570,432 @@ class TestClientFromTemplateJson(unittest.TestCase):
             ]
         }
 
+    def test_create_evaluator_public_resume_upload_options(self):
+        # Given
+        mock_post_response = MagicMock(status_code=200)
+        mock_post_response.json.return_value = self.mock_eval_response
+        mock_post_response.raise_for_status.return_value = None
+        self.api_client.post = MagicMock(return_value=mock_post_response)
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        state_path = os.path.join(temp_dir.name, "state.sqlite")
+
+        # When
+        evaluator = self.client.create_evaluator(
+            resume_upload=True,
+            upload_state_path=state_path,
+        )
+
+        # Then
+        self.assertTrue(evaluator._eval_config.resume_upload)  # type: ignore[attr-defined]
+        self.assertEqual(evaluator._eval_config.upload_state_path, state_path)  # type: ignore[attr-defined]
+        self.assertIsNotNone(evaluator._upload_ledger)  # type: ignore[attr-defined]
+        self.assertTrue(os.path.exists(state_path))
+
+    @unittest.skipIf(os.name == "nt", "POSIX symlink check")
+    def test_create_evaluator_validates_upload_state_path_before_backend_create(self):
+        mock_post_response = MagicMock(status_code=200)
+        mock_post_response.json.return_value = self.mock_eval_response
+        mock_post_response.raise_for_status.return_value = None
+        self.api_client.post = MagicMock(return_value=mock_post_response)
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        target_path = os.path.join(temp_dir.name, "target.sqlite")
+        symlink_path = os.path.join(temp_dir.name, "state.sqlite")
+        with open(target_path, "wb") as f:
+            f.write(b"")
+        os.symlink(target_path, symlink_path)
+
+        with self.assertRaises(ValueError):
+            self.client.create_evaluator(
+                resume_upload=True,
+                upload_state_path=symlink_path,
+            )
+
+        self.api_client.post.assert_not_called()
+
+    def test_resume_evaluator_reuses_existing_evaluation_and_ledger_remote_identity(self):
+        evaluation_id = str(uuid4())
+        state_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(state_dir.cleanup)
+        state_path = os.path.join(state_dir.name, "state.sqlite")
+        remote_name = "previous-run/remote-object.wav"
+        audio_path = os.path.join(os.path.dirname(__file__), "speech_ch1.mp3")
+        content_md5, file_size = calculate_file_md5_base64(audio_path)
+        manifest_audio = Audio(
+            path=audio_path,
+            name=os.path.basename(audio_path),
+            remote_object_name=remote_name,
+            script=None,
+            tags=[],
+            model_tag="model",
+            is_ref=False,
+            group=None,
+            type=QuestionFileType.STIMULUS,
+            order_in_group=0,
+        )
+        manifest_audio.set_integrity_info(content_md5, file_size)
+
+        ledger = UploadLedger(state_path)
+        ledger.upsert_queued_file(
+            evaluation_id, remote_name, audio_path, file_index=0
+        )
+        ledger.mark_md5_ready(
+            evaluation_id,
+            remote_name,
+            content_md5,
+            file_size,
+            manifest_hash=build_upload_manifest_hash(
+                manifest_audio.to_create_file_dict(), content_md5, file_size
+            ),
+        )
+        ledger.mark_uploaded(
+            evaluation_id,
+            remote_name,
+            "2026-05-22T00:00:00.000Z",
+            "2026-05-22T00:00:01.000Z",
+        )
+        ledger.mark_metadata_registering(evaluation_id, remote_name)
+        ledger.mark_metadata_registered(evaluation_id, remote_name)
+        ledger.mark_verified(evaluation_id, remote_name)
+        ledger.set_evaluation_contract(
+            evaluation_id,
+            _resume_contract(evaluation_id),
+        )
+
+        mock_get_response = MagicMock(status_code=200)
+        mock_get_response.json.return_value = {
+            "id": evaluation_id,
+            "title": "resumed",
+            "internal_name": "resumed",
+            "batch_size": 1,
+            "description": None,
+            "status": "DRAFT",
+            "created_time": "2024-03-21T06:18:09.659Z",
+            "updated_time": "2024-03-21T06:18:09.659Z",
+        }
+        mock_get_response.raise_for_status.return_value = None
+        self.api_client.get = MagicMock(return_value=mock_get_response)
+
+        evaluator = self.client.resume_evaluator(
+            evaluation_id=evaluation_id,
+            upload_state_path=state_path,
+            max_upload_workers=1,
+        )
+        evaluator._evaluation_service.process_files = MagicMock(  # type: ignore[method-assign]
+            return_value=SimpleNamespace(processing_count=1)
+        )
+        evaluator._evaluation_service.upload_session_json = MagicMock()  # type: ignore[method-assign]
+
+        evaluator.add_file(File(path=audio_path, model_tag="model"))
+        resumed_audio = evaluator._ordered_file_groups[0].audios[0]  # type: ignore[attr-defined]
+        self.assertEqual(resumed_audio.remote_object_name, remote_name)
+        result = evaluator.close()
+
+        self.assertEqual(result, {"status": "ok"})
+        self.assertEqual(evaluator.get_evaluation_id(), evaluation_id)
+        self.assertEqual(ledger.counts_by_status(evaluation_id)["verified"], 1)
+        self.assertEqual(evaluator._upload_manager._total_files, 0)  # type: ignore[union-attr]
+
+    def test_resume_evaluator_uses_template_id_from_ledger_contract(self):
+        evaluation_id = str(uuid4())
+        state_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(state_dir.cleanup)
+        state_path = os.path.join(state_dir.name, "state.sqlite")
+        template_id = "template-created-evaluation"
+        ledger = UploadLedger(state_path)
+        ledger.set_evaluation_contract(
+            evaluation_id,
+            _resume_contract(evaluation_id, eval_template_id=template_id),
+        )
+
+        mock_get_response = MagicMock(status_code=200)
+        mock_get_response.json.return_value = {
+            "id": evaluation_id,
+            "title": "resumed",
+            "internal_name": "resumed",
+            "batch_size": 1,
+            "description": None,
+            "status": "DRAFT",
+            "created_time": "2024-03-21T06:18:09.659Z",
+            "updated_time": "2024-03-21T06:18:09.659Z",
+        }
+        mock_get_response.raise_for_status.return_value = None
+        self.api_client.get = MagicMock(return_value=mock_get_response)
+
+        evaluator = self.client.resume_evaluator(
+            evaluation_id=evaluation_id,
+            upload_state_path=state_path,
+        )
+
+        self.assertEqual(evaluator._eval_config.eval_template_id, template_id)  # type: ignore[attr-defined]
+        self.assertEqual(evaluator.get_evaluation_id(), evaluation_id)
+
+    def test_resume_evaluator_uses_ranking_batch_size_from_ledger_contract(self):
+        evaluation_id = str(uuid4())
+        state_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(state_dir.cleanup)
+        state_path = os.path.join(state_dir.name, "state.sqlite")
+        ledger = UploadLedger(state_path)
+        ledger.set_evaluation_contract(
+            evaluation_id,
+            _resume_contract(
+                evaluation_id,
+                eval_type="RANKING",
+                eval_batch_size=3,
+            ),
+        )
+        mock_get_response = MagicMock(status_code=200)
+        mock_get_response.json.return_value = {
+            "id": evaluation_id,
+            "title": "resumed",
+            "internal_name": "resumed",
+            "batch_size": 3,
+            "description": None,
+            "status": "DRAFT",
+            "created_time": "2024-03-21T06:18:09.659Z",
+            "updated_time": "2024-03-21T06:18:09.659Z",
+        }
+        mock_get_response.raise_for_status.return_value = None
+        self.api_client.get = MagicMock(return_value=mock_get_response)
+
+        evaluator = self.client.resume_evaluator(
+            evaluation_id=evaluation_id,
+            upload_state_path=state_path,
+        )
+        evaluator._upload_one_file = MagicMock()  # type: ignore[method-assign]
+        audio_path = os.path.join(os.path.dirname(__file__), "speech_ch1.mp3")
+
+        evaluator.add_ranking_set(
+            [
+                File(path=audio_path, model_tag="model-a"),
+                File(path=audio_path, model_tag="model-b"),
+                File(path=audio_path, model_tag="model-c"),
+            ]
+        )
+
+        self.assertEqual(evaluator._eval_config.eval_type, EvalType.RANKING)  # type: ignore[attr-defined]
+        self.assertEqual(evaluator._eval_config.eval_batch_size, 3)  # type: ignore[attr-defined]
+        self.assertEqual(evaluator._upload_one_file.call_count, 3)  # type: ignore[attr-defined]
+
+    def test_resume_ranking_rejects_group_size_that_changes_contract(self):
+        evaluation_id = str(uuid4())
+        state_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(state_dir.cleanup)
+        state_path = os.path.join(state_dir.name, "state.sqlite")
+        ledger = UploadLedger(state_path)
+        ledger.set_evaluation_contract(
+            evaluation_id,
+            _resume_contract(
+                evaluation_id,
+                eval_type="RANKING",
+                eval_batch_size=3,
+            ),
+        )
+        mock_get_response = MagicMock(status_code=200)
+        mock_get_response.json.return_value = {
+            "id": evaluation_id,
+            "title": "resumed",
+            "internal_name": "resumed",
+            "batch_size": 3,
+            "description": None,
+            "status": "DRAFT",
+            "created_time": "2024-03-21T06:18:09.659Z",
+            "updated_time": "2024-03-21T06:18:09.659Z",
+        }
+        mock_get_response.raise_for_status.return_value = None
+        self.api_client.get = MagicMock(return_value=mock_get_response)
+
+        evaluator = self.client.resume_evaluator(
+            evaluation_id=evaluation_id,
+            upload_state_path=state_path,
+        )
+        evaluator._upload_one_file = MagicMock()  # type: ignore[method-assign]
+        evaluator._evaluation_service.update_specific_fields = MagicMock()  # type: ignore[method-assign]
+        audio_path = os.path.join(os.path.dirname(__file__), "speech_ch1.mp3")
+
+        with self.assertRaises(ValueError) as context:
+            evaluator.add_ranking_set(
+                [
+                    File(path=audio_path, model_tag="model-a"),
+                    File(path=audio_path, model_tag="model-b"),
+                ]
+            )
+
+        self.assertIn("original evaluation contract", str(context.exception))
+        self.assertEqual(evaluator._upload_one_file.call_count, 0)  # type: ignore[attr-defined]
+        evaluator._evaluation_service.update_specific_fields.assert_not_called()  # type: ignore[attr-defined]
+
+    def test_resume_evaluator_hydrates_original_session_config_from_ledger(self):
+        evaluation_id = str(uuid4())
+        state_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(state_dir.cleanup)
+        state_path = os.path.join(state_dir.name, "state.sqlite")
+        ledger = UploadLedger(state_path)
+        ledger.set_evaluation_contract(
+            evaluation_id,
+            _resume_contract(
+                evaluation_id,
+                session_overrides={
+                    "eval_name": "original-name",
+                    "eval_description": "original-desc",
+                    "eval_num": 7,
+                    "eval_auto_start": True,
+                    "verify_batch_size": 321,
+                },
+            ),
+        )
+        mock_get_response = MagicMock(status_code=200)
+        mock_get_response.json.return_value = {
+            "id": evaluation_id,
+            "title": "resumed",
+            "internal_name": "resumed",
+            "batch_size": 1,
+            "description": None,
+            "status": "DRAFT",
+            "created_time": "2024-03-21T06:18:09.659Z",
+            "updated_time": "2024-03-21T06:18:09.659Z",
+        }
+        mock_get_response.raise_for_status.return_value = None
+        self.api_client.get = MagicMock(return_value=mock_get_response)
+
+        evaluator = self.client.resume_evaluator(
+            evaluation_id=evaluation_id,
+            upload_state_path=state_path,
+            name="wrong-name",
+            desc="wrong-desc",
+            num_eval=99,
+            auto_start=False,
+            verify_batch_size=2,
+        )
+
+        session_config = evaluator._eval_config.to_dict()  # type: ignore[attr-defined]
+        self.assertEqual(session_config["eval_name"], "original-name")
+        self.assertEqual(session_config["eval_description"], "original-desc")
+        self.assertEqual(session_config["eval_num"], 7)
+        self.assertTrue(session_config["eval_auto_start"])
+        self.assertEqual(session_config["verify_batch_size"], 321)
+
+    def test_resume_evaluator_rejects_contract_without_session_config(self):
+        evaluation_id = str(uuid4())
+        state_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(state_dir.cleanup)
+        state_path = os.path.join(state_dir.name, "state.sqlite")
+        ledger = UploadLedger(state_path)
+        contract = _resume_contract(evaluation_id)
+        contract.pop("session_config")
+        ledger.set_evaluation_contract(evaluation_id, contract)
+        mock_get_response = MagicMock(status_code=200)
+        mock_get_response.json.return_value = {
+            "id": evaluation_id,
+            "title": "resumed",
+            "internal_name": "resumed",
+            "batch_size": 1,
+            "description": None,
+            "status": "DRAFT",
+            "created_time": "2024-03-21T06:18:09.659Z",
+            "updated_time": "2024-03-21T06:18:09.659Z",
+        }
+        mock_get_response.raise_for_status.return_value = None
+        self.api_client.get = MagicMock(return_value=mock_get_response)
+
+        with self.assertRaises(ValueError) as context:
+            self.client.resume_evaluator(
+                evaluation_id=evaluation_id,
+                upload_state_path=state_path,
+            )
+
+        self.assertIn("missing the original session configuration", str(context.exception))
+
+    def test_resume_evaluator_rejects_backend_batch_size_mismatch(self):
+        evaluation_id = str(uuid4())
+        state_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(state_dir.cleanup)
+        state_path = os.path.join(state_dir.name, "state.sqlite")
+        ledger = UploadLedger(state_path)
+        ledger.set_evaluation_contract(
+            evaluation_id,
+            _resume_contract(
+                evaluation_id,
+                eval_type="RANKING",
+                eval_batch_size=3,
+            ),
+        )
+        mock_get_response = MagicMock(status_code=200)
+        mock_get_response.json.return_value = {
+            "id": evaluation_id,
+            "title": "resumed",
+            "internal_name": "resumed",
+            "batch_size": 2,
+            "description": None,
+            "status": "DRAFT",
+            "created_time": "2024-03-21T06:18:09.659Z",
+            "updated_time": "2024-03-21T06:18:09.659Z",
+        }
+        mock_get_response.raise_for_status.return_value = None
+        self.api_client.get = MagicMock(return_value=mock_get_response)
+
+        with self.assertRaises(ValueError) as context:
+            self.client.resume_evaluator(
+                evaluation_id=evaluation_id,
+                upload_state_path=state_path,
+            )
+
+        self.assertIn("Backend evaluation batch_size", str(context.exception))
+
+    def test_resume_evaluator_rejects_path_like_evaluation_id(self):
+        with self.assertRaises(ValueError):
+            self.client.resume_evaluator(
+                evaluation_id="../../api-keys/last-used-time",
+                upload_state_path="/tmp/state.sqlite",
+            )
+
+    def test_resume_evaluator_rejects_missing_ledger_contract(self):
+        evaluation_id = str(uuid4())
+        state_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(state_dir.cleanup)
+        state_path = os.path.join(state_dir.name, "state.sqlite")
+        UploadLedger(state_path)
+        mock_get_response = MagicMock(status_code=200)
+        mock_get_response.json.return_value = {
+            "id": evaluation_id,
+            "title": "resumed",
+            "internal_name": "resumed",
+            "batch_size": 1,
+            "description": None,
+            "status": "DRAFT",
+            "created_time": "2024-03-21T06:18:09.659Z",
+            "updated_time": "2024-03-21T06:18:09.659Z",
+        }
+        mock_get_response.raise_for_status.return_value = None
+        self.api_client.get = MagicMock(return_value=mock_get_response)
+
+        with self.assertRaises(ValueError) as context:
+            self.client.resume_evaluator(
+                evaluation_id=evaluation_id,
+                upload_state_path=state_path,
+            )
+
+        self.assertIn("missing the original evaluation contract", str(context.exception))
+
+    def test_resume_evaluator_missing_upload_state_path_does_not_create_ledger(self):
+        evaluation_id = str(uuid4())
+        state_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(state_dir.cleanup)
+        state_path = os.path.join(state_dir.name, "missing-state.sqlite")
+        self.assertFalse(os.path.exists(state_path))
+        self.api_client.get = MagicMock()
+
+        with self.assertRaises(ValueError) as context:
+            self.client.resume_evaluator(
+                evaluation_id=evaluation_id,
+                upload_state_path=state_path,
+            )
+
+        self.assertIn("missing the original evaluation contract", str(context.exception))
+        self.assertFalse(os.path.exists(state_path))
+        self.api_client.get.assert_not_called()
+
     def test_create_evaluator_from_json_dict_single(self):
         # Given
         mock_post_response = MagicMock(status_code=200)
@@ -796,6 +1264,28 @@ class TestClient(unittest.TestCase):
                 }
             ]
         }
+
+    def test_create_evaluator_public_resume_upload_options(self):
+        # Given
+        mock_post_response = MagicMock(status_code=200)
+        mock_post_response.json.return_value = self.mock_eval_response
+        mock_post_response.raise_for_status.return_value = None
+        self.api_client.post = MagicMock(return_value=mock_post_response)
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        state_path = os.path.join(temp_dir.name, "state.sqlite")
+
+        # When
+        evaluator = self.client.create_evaluator(
+            resume_upload=True,
+            upload_state_path=state_path,
+        )
+
+        # Then
+        self.assertTrue(evaluator._eval_config.resume_upload)  # type: ignore[attr-defined]
+        self.assertEqual(evaluator._eval_config.upload_state_path, state_path)  # type: ignore[attr-defined]
+        self.assertIsNotNone(evaluator._upload_ledger)  # type: ignore[attr-defined]
+        self.assertTrue(os.path.exists(state_path))
 
     def test_create_evaluator_from_json_dict_single(self):
         # Given

--- a/tests/core/test_evaluator.py
+++ b/tests/core/test_evaluator.py
@@ -1,8 +1,10 @@
 import os
+import tempfile
 import unittest
 from datetime import datetime, timezone
 from typing import List
 from unittest.mock import Mock, patch
+from uuid import uuid4
 
 from glog import FailedCheckException  # type: ignore
 
@@ -11,6 +13,7 @@ from podonos.core.api import APIClient
 from podonos.core.config import EvalConfig, EvalConfigDefault
 from podonos.core.evaluator import Evaluator
 from podonos.core.file import Audio, AudioGroup, File
+from podonos.core.upload_ledger import UploadLedger
 from podonos.entity.evaluation import EvaluationEntity
 from podonos.entity.verification import FileVerificationResult, VerifyFilesResponse
 from podonos.errors import InvalidFileError
@@ -66,6 +69,52 @@ class TestEvaluator(unittest.TestCase):
         self.assertEqual(evaluator._eval_config, eval_config)  # type: ignore
         self.assertTrue(evaluator._initialized)  # type: ignore
         self.assertEqual(evaluator._ordered_file_groups, [])  # type: ignore
+
+    def test_upload_ledger_contract_mismatch_error_omits_raw_values(self):
+        state_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(state_dir.cleanup)
+        state_path = os.path.join(state_dir.name, "state.sqlite")
+        ledger = UploadLedger(state_path)
+        ledger.set_evaluation_contract(
+            "test_id",
+            {
+                "evaluation_id": "test_id",
+                "eval_type": EvalType.NMOS.value,
+                "eval_language": "en-us",
+                "eval_batch_size": 1,
+                "eval_template_id": None,
+                "use_annotation": False,
+                "use_loudness_normalization": True,
+                "session_config": {
+                    "eval_name": "customer pii name",
+                    "eval_description": "password=SECRET",
+                },
+            },
+        )
+        eval_config = EvalConfig(
+            name="different-name",
+            desc="different-description",
+            type=EvalType.NMOS.value,
+            resume_upload=True,
+            upload_state_path=state_path,
+        )
+
+        with self.assertRaises(ValueError) as context:
+            with patch.object(
+                Evaluator, "_set_evaluation", return_value=self.mock_evaluation
+            ):
+                Evaluator(
+                    api_client=self.api_client,
+                    eval_config=eval_config,
+                    supported_eval_types=[EvalType.NMOS],
+                )
+
+        message = str(context.exception)
+        self.assertIn("mismatched keys", message)
+        self.assertIn("session_config", message)
+        self.assertNotIn("customer pii name", message)
+        self.assertNotIn("password=SECRET", message)
+        self.assertNotIn("different-description", message)
 
     def test_should_create_evaluation_successfully(self):
         # Given
@@ -493,7 +542,7 @@ class TestEvaluator(unittest.TestCase):
         self.evaluator._ordered_file_groups = groups  # type: ignore
         mock_service = Mock()
 
-        def mock_verify_files(eval_id: str, batch: List[Audio]) -> VerifyFilesResponse:
+        def mock_verify_files(eval_id: str, batch: List[Audio], *args, **kwargs) -> VerifyFilesResponse:
             return self._create_mock_verify_response(batch)
 
         mock_service.verify_files.side_effect = mock_verify_files
@@ -506,8 +555,11 @@ class TestEvaluator(unittest.TestCase):
 
         # Then
         self.assertEqual(mock_service.create_evaluation_files.call_count, 2)
-        # verify_files should be called 2 times (600 files / 500 batch size = 2 batches)
-        self.assertEqual(mock_service.verify_files.call_count, 2)
+        for call in mock_service.create_evaluation_files.call_args_list:
+            self.assertEqual(call.kwargs["timeout"], self.evaluator._eval_config.api_timeout)  # type: ignore
+        # verify_files should be called 2 times (600 files / 100 batch size = 6 batches)
+        self.assertEqual(mock_service.verify_files.call_count, 6)
+        self.assertEqual(mock_service.process_files.call_args.kwargs["timeout"], self.evaluator._eval_config.api_timeout)  # type: ignore
 
     def test_verify_files_in_batches_single_batch(self):
         """Test _verify_files_in_batches with file count less than batch size."""
@@ -522,7 +574,12 @@ class TestEvaluator(unittest.TestCase):
         result = self.evaluator._verify_files_in_batches("eval_id", audios)  # type: ignore
 
         # Then
-        mock_service.verify_files.assert_called_once_with("eval_id", audios)
+        mock_service.verify_files.assert_called_once()
+        call = mock_service.verify_files.call_args
+        self.assertEqual(call.args[0], "eval_id")
+        self.assertEqual(call.args[1], audios)
+        self.assertEqual(call.kwargs["timeout"], self.evaluator._eval_config.verify_timeout)  # type: ignore
+        self.assertIn("batch_index", call.kwargs["context"])
         self.assertTrue(result.all_verified)
         self.assertEqual(result.verified_count, 100)
         self.assertEqual(result.failed_count, 0)
@@ -531,11 +588,11 @@ class TestEvaluator(unittest.TestCase):
     def test_verify_files_in_batches_multiple_batches(self):
         """Test _verify_files_in_batches with file count exceeding batch size."""
         # Given
-        total_files = 1200  # Should create 3 batches: 500 + 500 + 200
+        total_files = 1200  # Should create 12 batches of 100 by default
         audios = [self._create_test_audio(i) for i in range(total_files)]
         mock_service = Mock()
 
-        def mock_verify_files(eval_id: str, batch: List[Audio]) -> VerifyFilesResponse:
+        def mock_verify_files(eval_id: str, batch: List[Audio], *args, **kwargs) -> VerifyFilesResponse:
             return self._create_mock_verify_response(batch)
 
         mock_service.verify_files.side_effect = mock_verify_files
@@ -545,14 +602,13 @@ class TestEvaluator(unittest.TestCase):
         result = self.evaluator._verify_files_in_batches("eval_id", audios)  # type: ignore
 
         # Then
-        self.assertEqual(mock_service.verify_files.call_count, 3)
+        self.assertEqual(mock_service.verify_files.call_count, 12)
 
         # Verify batch sizes
         batch_size = self.evaluator._eval_config.verify_batch_size
         calls = mock_service.verify_files.call_args_list
-        self.assertEqual(len(calls[0][0][1]), batch_size)  # First batch: 500
-        self.assertEqual(len(calls[1][0][1]), batch_size)  # Second batch: 500
-        self.assertEqual(len(calls[2][0][1]), 200)  # Third batch: 200
+        self.assertEqual(len(calls[0][0][1]), batch_size)
+        self.assertEqual(len(calls[-1][0][1]), batch_size)
 
         # Verify aggregated results
         self.assertTrue(result.all_verified)
@@ -580,13 +636,13 @@ class TestEvaluator(unittest.TestCase):
     def test_verify_files_in_batches_aggregates_failures_correctly(self):
         """Test _verify_files_in_batches correctly aggregates failed results."""
         # Given
-        total_files = 1000  # 2 batches of 500
+        total_files = 1000  # 10 batches of 100 by default
         audios = [self._create_test_audio(i) for i in range(total_files)]
         mock_service = Mock()
 
         call_count = [0]
 
-        def mock_verify_files(eval_id: str, batch: List[Audio]) -> VerifyFilesResponse:
+        def mock_verify_files(eval_id: str, batch: List[Audio], *args, **kwargs) -> VerifyFilesResponse:
             # First batch: 3 failures (indices 0, 10, 20)
             # Second batch: 2 failures (indices 0, 5)
             if call_count[0] == 0:
@@ -606,13 +662,13 @@ class TestEvaluator(unittest.TestCase):
 
         # Then
         self.assertFalse(result.all_verified)
-        self.assertEqual(result.verified_count, 995)  # 1000 - 5 failures
-        self.assertEqual(result.failed_count, 5)  # 3 from first batch + 2 from second
+        self.assertEqual(result.verified_count, 979)  # 1000 - 21 failures across 10 batches
+        self.assertEqual(result.failed_count, 21)  # 3 from first batch + 2 from each remaining batch
         self.assertEqual(len(result.results), total_files)
 
         # Verify failed results are in the correct positions
         failed_results = [r for r in result.results if not r.verified]
-        self.assertEqual(len(failed_results), 5)
+        self.assertEqual(len(failed_results), 21)
 
     def test_verify_files_in_batches_empty_list(self):
         """Test _verify_files_in_batches with empty file list."""
@@ -631,14 +687,42 @@ class TestEvaluator(unittest.TestCase):
         self.assertEqual(result.failed_count, 0)
         self.assertEqual(len(result.results), 0)
 
+    def test_retry_failed_uploads_reregisters_metadata_before_verify(self):
+        """Failed verification retry must repair both bytes and metadata."""
+        failed_audio = self._create_test_audio(1)
+        mock_service = Mock()
+        self.evaluator._evaluation_service = mock_service  # type: ignore
+
+        with patch("podonos.core.evaluator.UploadManager") as mock_manager_cls:
+            mock_manager = Mock()
+            mock_manager_cls.return_value = mock_manager
+
+            self.evaluator._retry_failed_uploads([failed_audio])  # type: ignore
+
+        mock_manager.add_file_to_queue.assert_called_once_with(
+            self.evaluator.get_evaluation_id(), failed_audio
+        )
+        mock_manager.wait_and_close.assert_called_once()
+        mock_service.create_evaluation_files.assert_called_once_with(
+            self.evaluator.get_evaluation_id(),
+            [failed_audio],
+            timeout=self.evaluator._eval_config.api_timeout,  # type: ignore[attr-defined]
+            context={
+                "batch_index": 0,
+                "batch_size": 1,
+                "batch_start": 0,
+                "total_files": 1,
+            },
+        )
+
     def test_verify_files_in_batches_large_file_count(self):
         """Test _verify_files_in_batches with 1900 files (customer issue scenario)."""
         # Given
-        total_files = 1900  # Customer's file count: 500 + 500 + 500 + 400 = 4 batches
+        total_files = 1900  # Customer's file count; default verify_batch_size=100 means 19 batches
         audios = [self._create_test_audio(i) for i in range(total_files)]
         mock_service = Mock()
 
-        def mock_verify_files(eval_id: str, batch: List[Audio]) -> VerifyFilesResponse:
+        def mock_verify_files(eval_id: str, batch: List[Audio], *args, **kwargs) -> VerifyFilesResponse:
             return self._create_mock_verify_response(batch)
 
         mock_service.verify_files.side_effect = mock_verify_files
@@ -652,7 +736,7 @@ class TestEvaluator(unittest.TestCase):
         expected_batches = (total_files + batch_size - 1) // batch_size
         self.assertEqual(
             mock_service.verify_files.call_count, expected_batches
-        )  # 4 batches
+        )
         self.assertTrue(result.all_verified)
         self.assertEqual(result.verified_count, total_files)
         self.assertEqual(result.failed_count, 0)
@@ -673,7 +757,7 @@ class TestEvaluator(unittest.TestCase):
         self.evaluator._ordered_file_groups = groups  # type: ignore
         mock_service = Mock()
 
-        def mock_verify_files(eval_id: str, batch: List[Audio]) -> VerifyFilesResponse:
+        def mock_verify_files(eval_id: str, batch: List[Audio], *args, **kwargs) -> VerifyFilesResponse:
             return self._create_mock_verify_response(batch)
 
         mock_service.verify_files.side_effect = mock_verify_files
@@ -684,8 +768,8 @@ class TestEvaluator(unittest.TestCase):
         self.evaluator._process_audio_files_with_verification()  # type: ignore
 
         # Then
-        # verify_files should be called 3 times (1200 files / 500 batch size)
-        self.assertEqual(mock_service.verify_files.call_count, 3)
+        # verify_files should use the configured 100-file default batch size
+        self.assertEqual(mock_service.verify_files.call_count, 12)
         # create_evaluation_files should also be batched
         self.assertEqual(mock_service.create_evaluation_files.call_count, 3)
 
@@ -1156,7 +1240,69 @@ class TestEvaluator(unittest.TestCase):
         call_args = self.evaluator._evaluation_service.update_specific_fields.call_args  # type: ignore
         payload = call_args[0][1]
         self.assertEqual(payload["batch_size"], 3)
+        self.assertEqual(call_args.kwargs["timeout"], self.evaluator._eval_config.api_timeout)  # type: ignore
+        self.assertEqual(
+            call_args.kwargs["context"]["operation"],
+            "ranking_batch_size_resolution",
+        )
         self.assertEqual(self.evaluator._eval_config.eval_batch_size, 3)  # type: ignore
+
+    @patch.object(Evaluator, "_upload_one_file")
+    def test_resume_upload_ranking_persists_batch_size_before_first_upload(
+        self, mock_upload: Mock
+    ):
+        """Regression: crash after first RANKING upload must not leave batch_size=2."""
+        state_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(state_dir.cleanup)
+        state_path = os.path.join(state_dir.name, "ranking-resume.sqlite")
+        evaluation_id = str(uuid4())
+        current_time = datetime.now(timezone.utc)
+        ranking_evaluation = EvaluationEntity(
+            id=evaluation_id,
+            title="ranking",
+            internal_name=None,
+            description=None,
+            batch_size=2,
+            status="DRAFT",
+            created_time=current_time,
+            updated_time=current_time,
+        )
+        eval_config = EvalConfig(
+            type=EvalType.RANKING.value,
+            resume_upload=True,
+            upload_state_path=state_path,
+            api_timeout=(8, 88),
+        )
+        with patch.object(Evaluator, "_set_evaluation", return_value=ranking_evaluation):
+            evaluator = Evaluator(
+                api_client=self.api_client,
+                eval_config=eval_config,
+                supported_eval_types=[EvalType.RANKING],
+            )
+        evaluator._evaluation_service.update_specific_fields = Mock()  # type: ignore
+
+        evaluator.add_ranking_set(
+            [
+                File(path=self.test_wav, model_tag="A"),
+                File(path=self.test_wav, model_tag="B"),
+                File(path=self.test_wav, model_tag="C"),
+            ]
+        )
+
+        evaluator._evaluation_service.update_specific_fields.assert_called_once()  # type: ignore
+        call_args = evaluator._evaluation_service.update_specific_fields.call_args  # type: ignore
+        self.assertEqual(call_args[0][0], evaluation_id)
+        self.assertEqual(call_args[0][1]["batch_size"], 3)
+        self.assertEqual(call_args.kwargs["timeout"], (8, 88))
+        self.assertEqual(
+            call_args.kwargs["context"]["operation"],
+            "ranking_batch_size_resolution",
+        )
+        self.assertEqual(mock_upload.call_count, 3)
+        contract = UploadLedger(state_path).get_evaluation_contract(evaluation_id)
+        self.assertIsNotNone(contract)
+        self.assertEqual(contract["eval_batch_size"], 3)  # type: ignore[index]
+        self.assertEqual(evaluator._eval_config.eval_batch_size, 3)  # type: ignore
 
     @patch.object(Evaluator, "_upload_one_file")
     def test_update_specific_fields_receives_correct_batch_size_from_add_ranking_set(
@@ -1312,7 +1458,7 @@ class TestEvaluator(unittest.TestCase):
         audios = [self._create_test_audio(i) for i in range(total_files)]
         mock_service = Mock()
 
-        def mock_verify_files(eval_id: str, batch: List[Audio]) -> VerifyFilesResponse:
+        def mock_verify_files(eval_id: str, batch: List[Audio], *args, **kwargs) -> VerifyFilesResponse:
             return self._create_mock_verify_response(batch)
 
         mock_service.verify_files.side_effect = mock_verify_files
@@ -1341,9 +1487,8 @@ class TestEvaluator(unittest.TestCase):
         eval_config = EvalConfig(type=EvalType.NMOS.value)
 
         # Then
-        self.assertEqual(
-            eval_config.verify_batch_size, EvalConfigDefault.VERIFY_BATCH_SIZE
-        )
+        self.assertEqual(eval_config.verify_batch_size, EvalConfigDefault.VERIFY_BATCH_SIZE)
+        self.assertEqual(eval_config.verify_batch_size, 100)
 
     def test_eval_config_verify_batch_size_custom(self):
         """Test EvalConfig accepts custom verify_batch_size."""
@@ -1375,6 +1520,97 @@ class TestEvaluator(unittest.TestCase):
         # Given/When/Then - maximum value
         eval_config_max = EvalConfig(type=EvalType.NMOS.value, verify_batch_size=1000)
         self.assertEqual(eval_config_max.verify_batch_size, 1000)
+
+    def test_eval_config_timeout_defaults(self):
+        """Test EvalConfig exposes client-local timeout defaults."""
+        eval_config = EvalConfig(type=EvalType.NMOS.value)
+
+        self.assertEqual(eval_config.api_timeout, (5, 30))
+        self.assertEqual(eval_config.verify_timeout, (5, 120))
+        self.assertEqual(eval_config.upload_timeout, (10, 300))
+
+    def test_eval_config_timeout_custom_and_validation(self):
+        """Test EvalConfig accepts custom timeout tuples and rejects invalid values."""
+        eval_config = EvalConfig(
+            type=EvalType.NMOS.value,
+            api_timeout=(1, 2),
+            verify_timeout=(3, 4),
+            upload_timeout=(5, 6),
+        )
+
+        self.assertEqual(eval_config.api_timeout, (1, 2))
+        self.assertEqual(eval_config.verify_timeout, (3, 4))
+        self.assertEqual(eval_config.upload_timeout, (5, 6))
+
+        with self.assertRaises(ValueError):
+            EvalConfig(type=EvalType.NMOS.value, verify_timeout=(0, 10))
+        with self.assertRaises(ValueError):
+            EvalConfig(type=EvalType.NMOS.value, upload_timeout=(10, 1))
+        with self.assertRaises(ValueError):
+            EvalConfig(type=EvalType.NMOS.value, api_timeout=(True, 30))
+        with self.assertRaises(ValueError):
+            EvalConfig(type=EvalType.NMOS.value, api_timeout=(float("nan"), 30))
+        with self.assertRaises(ValueError):
+            EvalConfig(type=EvalType.NMOS.value, api_timeout=(5, float("inf")))
+
+    def test_eval_config_timeouts_are_client_local_not_serialized(self):
+        """Timeout config should not leak into session JSON / backend DTOs."""
+        eval_config = EvalConfig(
+            type=EvalType.NMOS.value,
+            api_timeout=(1, 2),
+            verify_timeout=(3, 4),
+            upload_timeout=(5, 6),
+        )
+
+        self.assertNotIn("api_timeout", eval_config.to_dict())
+        self.assertNotIn("verify_timeout", eval_config.to_dict())
+        self.assertNotIn("upload_timeout", eval_config.to_dict())
+        self.assertNotIn("api_timeout", eval_config.to_create_request_dto())
+        self.assertNotIn("verify_timeout", eval_config.to_create_request_dto())
+        self.assertNotIn("upload_timeout", eval_config.to_create_request_dto())
+
+    def test_eval_config_upload_ledger_defaults_are_opt_in(self):
+        """Ledger/resume config defaults off and does not require a state path."""
+        eval_config = EvalConfig(type=EvalType.NMOS.value)
+
+        self.assertFalse(eval_config.resume_upload)
+        self.assertIsNone(eval_config.upload_state_path)
+        self.assertEqual(
+            eval_config.resolve_upload_state_path(),
+            os.path.join(os.getcwd(), ".podonos_upload_state.sqlite"),
+        )
+
+    def test_eval_config_upload_ledger_custom_values_and_validation(self):
+        """Ledger/resume config accepts explicit opt-in values and validates types."""
+        eval_config = EvalConfig(
+            type=EvalType.NMOS.value,
+            resume_upload=True,
+            upload_state_path="/tmp/podonos-state.sqlite",
+        )
+
+        self.assertTrue(eval_config.resume_upload)
+        self.assertEqual(eval_config.upload_state_path, "/tmp/podonos-state.sqlite")
+        self.assertEqual(
+            eval_config.resolve_upload_state_path(), "/tmp/podonos-state.sqlite"
+        )
+
+        with self.assertRaises(ValueError):
+            EvalConfig(type=EvalType.NMOS.value, resume_upload="yes")  # type: ignore[arg-type]
+        with self.assertRaises(ValueError):
+            EvalConfig(type=EvalType.NMOS.value, upload_state_path="")
+
+    def test_eval_config_upload_ledger_is_client_local_not_serialized(self):
+        """Ledger path and resume flag should not leak into backend DTOs/session JSON."""
+        eval_config = EvalConfig(
+            type=EvalType.NMOS.value,
+            resume_upload=True,
+            upload_state_path="/tmp/podonos-state.sqlite",
+        )
+
+        for key in ("resume_upload", "upload_state_path"):
+            self.assertNotIn(key, eval_config.to_dict())
+            self.assertNotIn(key, eval_config.to_create_request_dto())
+            self.assertNotIn(key, eval_config.to_create_from_template_request_dto())
 
 
     # ----------------------------

--- a/tests/core/test_large_upload_flow.py
+++ b/tests/core/test_large_upload_flow.py
@@ -1,0 +1,835 @@
+import os
+import tempfile
+import unittest
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import List
+from unittest.mock import MagicMock, Mock, patch
+
+from podonos.common.enum import EvalType, QuestionFileType
+from podonos.common.util import calculate_file_md5_base64
+from podonos.core.api import APIClient
+from podonos.core.config import EvalConfig
+from podonos.core.evaluator import Evaluator
+from podonos.core.file import Audio, File
+from podonos.core.upload_ledger import (
+    build_upload_manifest_hash,
+    build_upload_manifest_key,
+)
+from podonos.entity.evaluation import EvaluationEntity
+from podonos.entity.verification import (
+    FileVerificationResult,
+    VerificationErrorDetail,
+    VerifyFilesResponse,
+)
+
+TESTDATA_SPEECH_CH1_MP3 = os.path.join(os.path.dirname(__file__), "speech_ch1.mp3")
+
+
+@dataclass
+class FakeAudio:
+    path: str
+    remote_object_name: str
+    is_silent: bool = False
+
+    def to_create_file_dict(self):
+        return {"uploaded_file_name": self.remote_object_name, "original_name": self.path}
+
+    def set_integrity_info(self, content_md5: str, file_size: int) -> None:
+        self.content_md5 = content_md5
+        self.file_size = file_size
+
+    def set_upload_at(self, start_at: str, finish_at: str) -> None:
+        self.upload_start_at = start_at
+        self.upload_finish_at = finish_at
+
+
+class TestLargeUploadLedgerFlow(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.state_path = os.path.join(self.temp_dir.name, "upload-state.sqlite")
+        self.evaluation = EvaluationEntity(
+            id="eval-ledger",
+            title="title",
+            internal_name=None,
+            description=None,
+            batch_size=1,
+            status="DRAFT",
+            created_time=datetime.now(timezone.utc),
+            updated_time=datetime.now(timezone.utc),
+        )
+
+    def make_evaluator(self, resume_upload: bool = True) -> Evaluator:
+        config = EvalConfig(
+            type=EvalType.NMOS.value,
+            verify_batch_size=100,
+            resume_upload=resume_upload,
+            upload_state_path=self.state_path,
+        )
+        with patch.object(Evaluator, "_set_evaluation", return_value=self.evaluation):
+            evaluator = Evaluator(
+                api_client=Mock(spec=APIClient),
+                eval_config=config,
+                supported_eval_types=EvalType.get_single_types(),
+            )
+        return evaluator
+
+    def fake_audios(self, count: int, prefix: str = "remote") -> List[FakeAudio]:
+        return [
+            FakeAudio(TESTDATA_SPEECH_CH1_MP3, f"{prefix}-{i:05d}.wav")
+            for i in range(count)
+        ]
+
+    def seed_rows(self, evaluator: Evaluator, audios: List[FakeAudio], status: str) -> None:
+        assert evaluator._upload_ledger is not None  # type: ignore[attr-defined]
+        now = "2026-05-22T00:00:00.000Z"
+        content_md5, file_size = calculate_file_md5_base64(TESTDATA_SPEECH_CH1_MP3)
+        for audio in audios:
+            audio.set_integrity_info(content_md5, file_size)
+        with evaluator._upload_ledger._transaction() as conn:  # type: ignore[union-attr]
+            conn.executemany(
+                """
+                INSERT INTO upload_ledger (
+                    evaluation_id,
+                    remote_object_name,
+                    local_path,
+                    status,
+                    content_md5,
+                    file_size,
+                    manifest_key,
+                    manifest_hash,
+                    upload_start_at,
+                    upload_finish_at,
+                    created_at,
+                    updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                [
+                    (
+                        evaluator.get_evaluation_id(),
+                        audio.remote_object_name,
+                        audio.path,
+                        status,
+                        content_md5,
+                        file_size,
+                        build_upload_manifest_key(
+                            audio.to_create_file_dict(), content_md5, file_size
+                        ),
+                        build_upload_manifest_hash(
+                            audio.to_create_file_dict(), content_md5, file_size
+                        ),
+                        now,
+                        now,
+                        now,
+                        now,
+                    )
+                    for audio in audios
+                ],
+            )
+
+    def configure_verify_all_success(self, evaluator: Evaluator) -> MagicMock:
+        service = MagicMock()
+        service.process_files.return_value = SimpleNamespace(processing_count=0)
+
+        def verify_files(evaluation_id, audios, **kwargs):
+            return VerifyFilesResponse(
+                all_verified=True,
+                verified_count=len(audios),
+                failed_count=0,
+                results=[
+                    FileVerificationResult(
+                        uploaded_file_name=audio.remote_object_name,
+                        verified=True,
+                        file_meta_id=f"meta-{index}",
+                        error=None,
+                    )
+                    for index, audio in enumerate(audios)
+                ],
+            )
+
+        service.verify_files.side_effect = verify_files
+        evaluator._evaluation_service = service  # type: ignore[assignment]
+        return service
+
+    def test_5k_fake_flow_registers_metadata_verifies_and_bounds_success_results(self):
+        evaluator = self.make_evaluator()
+        audios = self.fake_audios(5000)
+        self.seed_rows(evaluator, audios, "uploaded")
+        evaluator._ordered_file_groups = [SimpleNamespace(audios=audios)]  # type: ignore[assignment]
+        service = self.configure_verify_all_success(evaluator)
+
+        evaluator._process_audio_files_with_verification()  # type: ignore[arg-type]
+
+        self.assertEqual(service.create_evaluation_files.call_count, 10)
+        self.assertEqual(service.verify_files.call_count, 50)
+        self.assertEqual(
+            evaluator._upload_ledger.counts_by_status(evaluator.get_evaluation_id())["verified"],  # type: ignore[union-attr]
+            5000,
+        )
+
+        response = evaluator._verify_files_in_batches(evaluator.get_evaluation_id(), audios)  # type: ignore[arg-type]
+        self.assertTrue(response.all_verified)
+        self.assertEqual(response.verified_count, 5000)
+        self.assertEqual(response.results, [])
+
+    def test_duplicate_identical_files_do_not_collapse_ledger_identity(self):
+        evaluator = self.make_evaluator()
+        evaluator._evaluation_service.get_presigned_url = MagicMock(  # type: ignore[method-assign]
+            return_value="https://example.com/presigned-url"
+        )
+        evaluator._evaluation_service.upload_evaluation_file = MagicMock(  # type: ignore[method-assign]
+            return_value=MagicMock()
+        )
+        duplicate_file = File(path=TESTDATA_SPEECH_CH1_MP3, model_tag="same-model")
+
+        evaluator.add_file(duplicate_file)
+        evaluator.add_file(duplicate_file)
+        evaluator._wait_for_uploads()
+
+        assert evaluator._upload_ledger is not None
+        uploaded_rows = evaluator._upload_ledger.list_by_status(
+            evaluator.get_evaluation_id(), "uploaded"
+        )
+        self.assertEqual(len(uploaded_rows), 2)
+        self.assertEqual(
+            len({row.remote_object_name for row in uploaded_rows}),
+            2,
+        )
+        self.assertEqual(
+            evaluator._evaluation_service.upload_evaluation_file.call_count,  # type: ignore[attr-defined]
+            2,
+        )
+
+    def test_interrupted_resume_skips_verified_and_partial_metadata(self):
+        evaluator = self.make_evaluator()
+        verified = self.fake_audios(1, prefix="verified")
+        metadata_registered = self.fake_audios(1, prefix="registered")
+        uploaded = self.fake_audios(1, prefix="uploaded")
+        self.seed_rows(evaluator, verified, "verified")
+        self.seed_rows(evaluator, metadata_registered, "metadata_registered")
+        self.seed_rows(evaluator, uploaded, "uploaded")
+        audios = verified + metadata_registered + uploaded
+        evaluator._ordered_file_groups = [SimpleNamespace(audios=audios)]  # type: ignore[assignment]
+        service = self.configure_verify_all_success(evaluator)
+
+        evaluator._process_audio_files_with_verification()  # type: ignore[arg-type]
+
+        service.create_evaluation_files.assert_called_once()
+        registered_batch = service.create_evaluation_files.call_args.args[1]
+        self.assertEqual([audio.remote_object_name for audio in registered_batch], [uploaded[0].remote_object_name])
+        service.verify_files.assert_called_once()
+        verified_batch = service.verify_files.call_args.args[1]
+        self.assertEqual(
+            {audio.remote_object_name for audio in verified_batch},
+            {metadata_registered[0].remote_object_name, uploaded[0].remote_object_name},
+        )
+        self.assertEqual(
+            evaluator._upload_ledger.counts_by_status(evaluator.get_evaluation_id())["verified"],  # type: ignore[union-attr]
+            3,
+        )
+
+    def test_metadata_registering_resume_verifies_before_reregistering(self):
+        evaluator = self.make_evaluator()
+        audios = self.fake_audios(2, prefix="registering")
+        self.seed_rows(evaluator, audios, "metadata_registering")
+        evaluator._ordered_file_groups = [SimpleNamespace(audios=audios)]  # type: ignore[assignment]
+        service = self.configure_verify_all_success(evaluator)
+
+        evaluator._process_audio_files_with_verification()  # type: ignore[arg-type]
+
+        service.create_evaluation_files.assert_not_called()
+        service.verify_files.assert_called_once()
+        self.assertEqual(
+            evaluator._upload_ledger.counts_by_status(evaluator.get_evaluation_id())["verified"],  # type: ignore[union-attr]
+            2,
+        )
+
+    def test_metadata_registering_verification_failure_retries_metadata_not_upload(self):
+        evaluator = self.make_evaluator()
+        audios = self.fake_audios(1, prefix="registering-missing")
+        self.seed_rows(evaluator, audios, "metadata_registering")
+        evaluator._ordered_file_groups = [SimpleNamespace(audios=audios)]  # type: ignore[assignment]
+
+        service = MagicMock()
+        service.process_files.return_value = SimpleNamespace(processing_count=0)
+        service.verify_files.side_effect = [
+            VerifyFilesResponse(
+                all_verified=False,
+                verified_count=0,
+                failed_count=1,
+                results=[
+                    FileVerificationResult(
+                        audios[0].remote_object_name,
+                        False,
+                        None,
+                        VerificationErrorDetail(
+                            code="METADATA_NOT_FOUND",
+                            message="metadata is not registered",
+                            expected=None,
+                            actual=None,
+                        ),
+                    )
+                ],
+            ),
+            VerifyFilesResponse(
+                all_verified=True,
+                verified_count=1,
+                failed_count=0,
+                results=[
+                    FileVerificationResult(
+                        audios[0].remote_object_name,
+                        True,
+                        "meta-0",
+                        None,
+                    )
+                ],
+            ),
+        ]
+        evaluator._evaluation_service = service  # type: ignore[assignment]
+
+        evaluator._process_audio_files_with_verification()  # type: ignore[arg-type]
+
+        service.create_evaluation_files.assert_called_once()
+        service.get_presigned_url.assert_not_called()
+        service.upload_evaluation_file.assert_not_called()
+        self.assertEqual(
+            evaluator._upload_ledger.get(  # type: ignore[union-attr]
+                evaluator.get_evaluation_id(), audios[0].remote_object_name
+            ).status,
+            "verified",
+        )
+
+    def test_upload_retry_registers_metadata_before_reverification(self):
+        evaluator = self.make_evaluator()
+        audios = self.fake_audios(1, prefix="upload-retry-metadata")
+        self.seed_rows(evaluator, audios, "metadata_registered")
+        evaluator._ordered_file_groups = [SimpleNamespace(audios=audios)]  # type: ignore[assignment]
+
+        service = evaluator._evaluation_service
+        service.process_files = MagicMock(  # type: ignore[method-assign]
+            return_value=SimpleNamespace(processing_count=0)
+        )
+        service.get_presigned_url = MagicMock(  # type: ignore[method-assign]
+            return_value="https://example.com/presigned-url"
+        )
+        service.upload_evaluation_file = MagicMock(  # type: ignore[method-assign]
+            return_value=MagicMock()
+        )
+        service.create_evaluation_files = MagicMock()  # type: ignore[method-assign]
+        failure_response = VerifyFilesResponse(
+            all_verified=False,
+            verified_count=0,
+            failed_count=1,
+            results=[
+                FileVerificationResult(
+                    audios[0].remote_object_name,
+                    False,
+                    None,
+                    VerificationErrorDetail(
+                        code="METADATA_NOT_FOUND",
+                        message="metadata missing after upload",
+                        expected=None,
+                        actual=None,
+                    ),
+                )
+            ],
+        )
+        success_response = VerifyFilesResponse(
+            all_verified=True,
+            verified_count=1,
+            failed_count=0,
+            results=[
+                FileVerificationResult(
+                    audios[0].remote_object_name,
+                    True,
+                    "meta-after-retry",
+                    None,
+                )
+            ],
+        )
+
+        def verify_after_metadata_retry(*args, **kwargs):
+            if service.verify_files.call_count == 1:  # type: ignore[attr-defined]
+                return failure_response
+            self.assertTrue(service.create_evaluation_files.called)  # type: ignore[attr-defined]
+            return success_response
+
+        service.verify_files = MagicMock(  # type: ignore[method-assign]
+            side_effect=verify_after_metadata_retry
+        )
+
+        evaluator._process_audio_files_with_verification()  # type: ignore[arg-type]
+
+        service.upload_evaluation_file.assert_called_once()
+        service.create_evaluation_files.assert_called_once()
+        self.assertEqual(service.verify_files.call_count, 2)
+
+    def test_metadata_registration_create_failure_rolls_back_to_uploaded(self):
+        evaluator = self.make_evaluator()
+        audios = self.fake_audios(2, prefix="metadata-timeout")
+        self.seed_rows(evaluator, audios, "uploaded")
+        evaluator._ordered_file_groups = [SimpleNamespace(audios=audios)]  # type: ignore[assignment]
+        service = MagicMock()
+        service.process_files.return_value = SimpleNamespace(processing_count=0)
+        service.create_evaluation_files.side_effect = RuntimeError(
+            "create timed out client_secret=SECRET"
+        )
+        evaluator._evaluation_service = service  # type: ignore[assignment]
+
+        with self.assertRaises(RuntimeError):
+            evaluator._process_audio_files_with_verification()  # type: ignore[arg-type]
+
+        assert evaluator._upload_ledger is not None
+        for audio in audios:
+            row = evaluator._upload_ledger.get(
+                evaluator.get_evaluation_id(), audio.remote_object_name
+            )
+            self.assertEqual(row.status, "uploaded")  # type: ignore[union-attr]
+            self.assertNotIn("SECRET", row.error_message)  # type: ignore[union-attr]
+        service.verify_files.assert_not_called()
+        service.get_presigned_url.assert_not_called()
+        service.upload_evaluation_file.assert_not_called()
+
+    def test_processed_finalization_skips_backend_process_replay(self):
+        evaluator = self.make_evaluator()
+        audios = self.fake_audios(2, prefix="finalized")
+        self.seed_rows(evaluator, audios, "verified")
+        evaluator._ordered_file_groups = [SimpleNamespace(audios=audios)]  # type: ignore[assignment]
+        service = self.configure_verify_all_success(evaluator)
+        assert evaluator._upload_ledger is not None
+        request_hash = evaluator._finalization_hash(  # type: ignore[attr-defined]
+            {
+                "evaluation_id": evaluator.get_evaluation_id(),
+                "files": [audio.to_create_file_dict() for audio in audios],
+            }
+        )
+        evaluator._upload_ledger.mark_processed(
+            evaluator.get_evaluation_id(), 2, request_hash
+        )
+
+        evaluator._process_audio_files_with_verification()  # type: ignore[arg-type]
+
+        service.process_files.assert_not_called()
+
+    def test_processed_finalization_hash_mismatch_replays_backend_process(self):
+        evaluator = self.make_evaluator()
+        audios = self.fake_audios(2, prefix="changed-finalized")
+        self.seed_rows(evaluator, audios, "verified")
+        evaluator._ordered_file_groups = [SimpleNamespace(audios=audios)]  # type: ignore[assignment]
+        service = self.configure_verify_all_success(evaluator)
+        assert evaluator._upload_ledger is not None
+        evaluator._upload_ledger.mark_processed(
+            evaluator.get_evaluation_id(), 2, "different-request-hash"
+        )
+
+        evaluator._process_audio_files_with_verification()  # type: ignore[arg-type]
+
+        service.process_files.assert_called_once()
+
+    def test_process_success_records_finalization_state(self):
+        evaluator = self.make_evaluator()
+        audios = self.fake_audios(1, prefix="process-finalized")
+        self.seed_rows(evaluator, audios, "verified")
+        evaluator._ordered_file_groups = [SimpleNamespace(audios=audios)]  # type: ignore[assignment]
+        service = self.configure_verify_all_success(evaluator)
+
+        evaluator._process_audio_files_with_verification()  # type: ignore[arg-type]
+
+        service.process_files.assert_called_once()
+        assert evaluator._upload_ledger is not None
+        self.assertTrue(
+            evaluator._upload_ledger.is_processed(evaluator.get_evaluation_id())
+        )
+
+    def test_session_json_finalization_skips_reupload(self):
+        evaluator = self.make_evaluator()
+        service = MagicMock()
+        evaluator._evaluation_service = service  # type: ignore[assignment]
+        assert evaluator._upload_ledger is not None
+        evaluator._upload_ledger.mark_session_json_uploaded(
+            evaluator.get_evaluation_id(),
+            evaluator._finalization_hash(evaluator._session_json_payload()),  # type: ignore[attr-defined]
+        )
+
+        evaluator._upload_session_json()  # type: ignore[attr-defined]
+
+        service.upload_session_json.assert_not_called()
+
+    def test_session_json_finalization_hash_mismatch_reuploads(self):
+        evaluator = self.make_evaluator()
+        service = MagicMock()
+        evaluator._evaluation_service = service  # type: ignore[assignment]
+        assert evaluator._upload_ledger is not None
+        evaluator._upload_ledger.mark_session_json_uploaded(
+            evaluator.get_evaluation_id(), "different-session-json-hash"
+        )
+
+        evaluator._upload_session_json()  # type: ignore[attr-defined]
+
+        service.upload_session_json.assert_called_once()
+
+    def test_stable_manifest_identity_prevents_order_based_remote_misbind(self):
+        evaluator = self.make_evaluator()
+        audio_path = TESTDATA_SPEECH_CH1_MP3
+        old_a = Audio(
+            path=audio_path,
+            name="speech_ch1.mp3",
+            remote_object_name="old-a.wav",
+            script="script-a",
+            tags=["tag-a"],
+            model_tag="model-a",
+            is_ref=False,
+            group=None,
+            type=QuestionFileType.STIMULUS,
+            order_in_group=0,
+        )
+        old_b = Audio(
+            path=audio_path,
+            name="speech_ch1.mp3",
+            remote_object_name="old-b.wav",
+            script="script-b",
+            tags=["tag-b"],
+            model_tag="model-b",
+            is_ref=False,
+            group=None,
+            type=QuestionFileType.STIMULUS,
+            order_in_group=0,
+        )
+        assert evaluator._upload_ledger is not None
+        content_md5, file_size = calculate_file_md5_base64(audio_path)
+        for index, audio in enumerate([old_a, old_b]):
+            audio.set_integrity_info(content_md5, file_size)
+            manifest_key = build_upload_manifest_key(
+                audio.to_create_file_dict(), content_md5, file_size
+            )
+            manifest_hash = build_upload_manifest_hash(
+                audio.to_create_file_dict(), content_md5, file_size
+            )
+            evaluator._upload_ledger.upsert_queued_file(
+                evaluator.get_evaluation_id(),
+                audio.remote_object_name,
+                audio.path,
+                file_index=index,
+                manifest_key=manifest_key,
+            )
+            evaluator._upload_ledger.mark_md5_ready(
+                evaluator.get_evaluation_id(),
+                audio.remote_object_name,
+                content_md5,
+                file_size,
+                manifest_key=manifest_key,
+                manifest_hash=manifest_hash,
+            )
+            evaluator._upload_ledger.mark_uploaded(
+                evaluator.get_evaluation_id(),
+                audio.remote_object_name,
+                "2026-05-22T00:00:00.000Z",
+                "2026-05-22T00:00:01.000Z",
+            )
+            evaluator._upload_ledger.mark_metadata_registered(
+                evaluator.get_evaluation_id(), audio.remote_object_name
+            )
+            evaluator._upload_ledger.mark_verified(
+                evaluator.get_evaluation_id(), audio.remote_object_name
+            )
+
+        new_b = Audio(
+            path=audio_path,
+            name="speech_ch1.mp3",
+            remote_object_name="new-b.wav",
+            script="script-b",
+            tags=["tag-b"],
+            model_tag="model-b",
+            is_ref=False,
+            group=None,
+            type=QuestionFileType.STIMULUS,
+            order_in_group=0,
+        )
+        new_a = Audio(
+            path=audio_path,
+            name="speech_ch1.mp3",
+            remote_object_name="new-a.wav",
+            script="script-a",
+            tags=["tag-a"],
+            model_tag="model-a",
+            is_ref=False,
+            group=None,
+            type=QuestionFileType.STIMULUS,
+            order_in_group=0,
+        )
+
+        self.assertTrue(evaluator._should_skip_upload(new_b))  # type: ignore[attr-defined]
+        self.assertEqual(new_b.remote_object_name, "old-b.wav")
+        self.assertTrue(evaluator._should_skip_upload(new_a))  # type: ignore[attr-defined]
+        self.assertEqual(new_a.remote_object_name, "old-a.wav")
+
+    def test_verified_ledger_row_rejects_changed_local_file(self):
+        evaluator = self.make_evaluator()
+        local_path = os.path.join(self.temp_dir.name, "changed.wav")
+        with open(local_path, "wb") as f:
+            f.write(b"original")
+
+        audio = FakeAudio(local_path, "changed-remote.wav")
+        assert evaluator._upload_ledger is not None
+        content_md5, file_size = calculate_file_md5_base64(local_path)
+        evaluator._upload_ledger.upsert_queued_file(
+            evaluator.get_evaluation_id(), audio.remote_object_name, audio.path
+        )
+        evaluator._upload_ledger.mark_md5_ready(
+            evaluator.get_evaluation_id(), audio.remote_object_name, content_md5, file_size
+        )
+        evaluator._upload_ledger.mark_uploaded(
+            evaluator.get_evaluation_id(),
+            audio.remote_object_name,
+            "2026-05-22T00:00:00.000Z",
+            "2026-05-22T00:00:01.000Z",
+        )
+        evaluator._upload_ledger.mark_metadata_registering(
+            evaluator.get_evaluation_id(), audio.remote_object_name
+        )
+        evaluator._upload_ledger.mark_metadata_registered(
+            evaluator.get_evaluation_id(), audio.remote_object_name
+        )
+        evaluator._upload_ledger.mark_verified(
+            evaluator.get_evaluation_id(), audio.remote_object_name
+        )
+
+        with open(local_path, "wb") as f:
+            f.write(b"changed")
+
+        with self.assertRaises(ValueError):
+            evaluator._verify_files_in_batches(evaluator.get_evaluation_id(), [audio])  # type: ignore[arg-type]
+
+    def test_verified_ledger_row_rejects_changed_file_metadata_contract(self):
+        evaluator = self.make_evaluator()
+        old_audio = Audio(
+            path=TESTDATA_SPEECH_CH1_MP3,
+            name="speech_ch1.mp3",
+            remote_object_name="metadata-contract.mp3",
+            script="original script",
+            tags=["original-tag"],
+            model_tag="old-model",
+            is_ref=False,
+            group=None,
+            type=QuestionFileType.STIMULUS,
+            order_in_group=0,
+        )
+        new_audio = Audio(
+            path=TESTDATA_SPEECH_CH1_MP3,
+            name="speech_ch1.mp3",
+            remote_object_name="metadata-contract.mp3",
+            script="changed script",
+            tags=["changed-tag"],
+            model_tag="new-model",
+            is_ref=False,
+            group=None,
+            type=QuestionFileType.STIMULUS,
+            order_in_group=0,
+        )
+        assert evaluator._upload_ledger is not None
+        content_md5, file_size = calculate_file_md5_base64(TESTDATA_SPEECH_CH1_MP3)
+        old_audio.set_integrity_info(content_md5, file_size)
+        evaluator._upload_ledger.upsert_queued_file(
+            evaluator.get_evaluation_id(), old_audio.remote_object_name, old_audio.path
+        )
+        evaluator._upload_ledger.mark_md5_ready(
+            evaluator.get_evaluation_id(),
+            old_audio.remote_object_name,
+            content_md5,
+            file_size,
+            manifest_hash=build_upload_manifest_hash(
+                old_audio.to_create_file_dict(), content_md5, file_size
+            ),
+        )
+        evaluator._upload_ledger.mark_uploaded(
+            evaluator.get_evaluation_id(),
+            old_audio.remote_object_name,
+            "2026-05-22T00:00:00.000Z",
+            "2026-05-22T00:00:01.000Z",
+        )
+        evaluator._upload_ledger.mark_metadata_registered(
+            evaluator.get_evaluation_id(), old_audio.remote_object_name
+        )
+        evaluator._upload_ledger.mark_verified(
+            evaluator.get_evaluation_id(), old_audio.remote_object_name
+        )
+
+        with self.assertRaises(ValueError):
+            evaluator._verify_files_in_batches(evaluator.get_evaluation_id(), [new_audio])
+
+    def test_ledger_verification_does_not_aggregate_success_results(self):
+        evaluator = self.make_evaluator()
+        audios = self.fake_audios(250, prefix="success")
+        self.seed_rows(evaluator, audios, "metadata_registered")
+        service = self.configure_verify_all_success(evaluator)
+
+        response = evaluator._verify_files_in_batches(evaluator.get_evaluation_id(), audios)  # type: ignore[arg-type]
+
+        self.assertEqual(service.verify_files.call_count, 3)
+        self.assertTrue(response.all_verified)
+        self.assertEqual(response.verified_count, 250)
+        self.assertEqual(response.failed_count, 0)
+        self.assertEqual(response.results, [])
+
+    def test_verify_failed_status_is_persisted_and_retry_can_verify(self):
+        evaluator = self.make_evaluator()
+        audios = self.fake_audios(2)
+        self.seed_rows(evaluator, audios, "metadata_registered")
+        service = MagicMock()
+        service.verify_files.return_value = VerifyFilesResponse(
+            all_verified=False,
+            verified_count=1,
+            failed_count=1,
+            results=[
+                FileVerificationResult(audios[0].remote_object_name, True, "meta-0", None),
+                FileVerificationResult(
+                    audios[1].remote_object_name,
+                    False,
+                    None,
+                    VerificationErrorDetail(
+                        code="SIZE_MISMATCH",
+                        message="expected bytes > 0",
+                        expected="1",
+                        actual="0",
+                    ),
+                ),
+            ],
+        )
+        evaluator._evaluation_service = service  # type: ignore[assignment]
+
+        response = evaluator._verify_files_in_batches(evaluator.get_evaluation_id(), audios)  # type: ignore[arg-type]
+
+        self.assertFalse(response.all_verified)
+        self.assertEqual(len(response.results), 1)
+        self.assertEqual(
+            evaluator._upload_ledger.get(evaluator.get_evaluation_id(), audios[1].remote_object_name).status,  # type: ignore[union-attr]
+            "verify_failed",
+        )
+
+        service.verify_files.return_value = VerifyFilesResponse(
+            all_verified=True,
+            verified_count=1,
+            failed_count=0,
+            results=[
+                FileVerificationResult(audios[1].remote_object_name, True, "meta-1", None)
+            ],
+        )
+        retry_response = evaluator._verify_files_in_batches(  # type: ignore[arg-type]
+            evaluator.get_evaluation_id(), [audios[1]]
+        )
+        self.assertTrue(retry_response.all_verified)
+        self.assertEqual(
+            evaluator._upload_ledger.counts_by_status(evaluator.get_evaluation_id())["verified"],  # type: ignore[union-attr]
+            2,
+        )
+
+    def test_upload_failed_row_is_retried_and_marked_uploaded(self):
+        evaluator = self.make_evaluator()
+        audio = Audio(
+            path=TESTDATA_SPEECH_CH1_MP3,
+            name="speech_ch1.mp3",
+            remote_object_name="remote-retry.mp3",
+            script=None,
+            tags=[],
+            model_tag="model",
+            is_ref=False,
+            group=None,
+            type=QuestionFileType.STIMULUS,
+            order_in_group=0,
+        )
+        assert evaluator._upload_ledger is not None
+        evaluator._upload_ledger.upsert_queued_file(
+            evaluator.get_evaluation_id(), audio.remote_object_name, audio.path
+        )
+        evaluator._upload_ledger.mark_upload_failed(
+            evaluator.get_evaluation_id(), audio.remote_object_name, "RuntimeError", "first upload failed"
+        )
+        evaluator._evaluation_service.get_presigned_url = MagicMock(  # type: ignore[method-assign]
+            return_value="https://example.com/presigned-url"
+        )
+        evaluator._evaluation_service.upload_evaluation_file = MagicMock(return_value=MagicMock())  # type: ignore[method-assign]
+
+        evaluator._upload_one_file(evaluator.get_evaluation_id(), audio)
+        evaluator._wait_for_uploads()
+
+        row = evaluator._upload_ledger.get(evaluator.get_evaluation_id(), audio.remote_object_name)
+        self.assertEqual(row.status, "uploaded")  # type: ignore[union-attr]
+        evaluator._evaluation_service.upload_evaluation_file.assert_called_once()  # type: ignore[attr-defined]
+
+    def test_upload_failed_row_with_changed_path_resets_before_retry(self):
+        evaluator = self.make_evaluator()
+        old_path = os.path.join(self.temp_dir.name, "old.wav")
+        new_path = os.path.join(self.temp_dir.name, "new.wav")
+        with open(old_path, "wb") as f:
+            f.write(b"old audio")
+        with open(new_path, "wb") as f:
+            f.write(b"new audio")
+
+        audio = FakeAudio(new_path, "stale-upload-failed.wav")
+        assert evaluator._upload_ledger is not None
+        evaluator._upload_ledger.upsert_queued_file(
+            evaluator.get_evaluation_id(), audio.remote_object_name, old_path
+        )
+        old_md5, old_size = calculate_file_md5_base64(old_path)
+        evaluator._upload_ledger.mark_md5_ready(
+            evaluator.get_evaluation_id(),
+            audio.remote_object_name,
+            old_md5,
+            old_size,
+        )
+        evaluator._upload_ledger.mark_upload_failed(
+            evaluator.get_evaluation_id(),
+            audio.remote_object_name,
+            "RuntimeError",
+            "first path failed",
+        )
+
+        self.assertFalse(evaluator._should_skip_upload(audio))  # type: ignore[arg-type]
+
+        row = evaluator._upload_ledger.get(
+            evaluator.get_evaluation_id(), audio.remote_object_name
+        )
+        self.assertIsNotNone(row)
+        self.assertEqual(row.status, "queued")
+        self.assertEqual(row.local_path, new_path)
+        self.assertIsNone(row.content_md5)
+        self.assertIsNone(row.file_size)
+
+    def test_queued_row_with_changed_path_resets_before_retry(self):
+        evaluator = self.make_evaluator()
+        old_path = os.path.join(self.temp_dir.name, "old-queued.wav")
+        new_path = os.path.join(self.temp_dir.name, "new-queued.wav")
+        with open(old_path, "wb") as f:
+            f.write(b"old audio")
+        with open(new_path, "wb") as f:
+            f.write(b"new audio")
+
+        audio = FakeAudio(new_path, "stale-queued.wav")
+        assert evaluator._upload_ledger is not None
+        evaluator._upload_ledger.upsert_queued_file(
+            evaluator.get_evaluation_id(),
+            audio.remote_object_name,
+            old_path,
+            file_index=0,
+        )
+
+        self.assertFalse(evaluator._should_skip_upload(audio))  # type: ignore[arg-type]
+
+        row = evaluator._upload_ledger.get(
+            evaluator.get_evaluation_id(), audio.remote_object_name
+        )
+        self.assertIsNotNone(row)
+        self.assertEqual(row.status, "queued")
+        self.assertEqual(row.local_path, new_path)
+
+    def test_default_evaluator_does_not_create_state_file(self):
+        evaluator = self.make_evaluator(resume_upload=False)
+
+        self.assertIsNone(evaluator._upload_ledger)  # type: ignore[attr-defined]
+        self.assertFalse(os.path.exists(self.state_path))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/core/test_large_upload_flow.py
+++ b/tests/core/test_large_upload_flow.py
@@ -392,6 +392,33 @@ class TestLargeUploadLedgerFlow(unittest.TestCase):
         service.get_presigned_url.assert_not_called()
         service.upload_evaluation_file.assert_not_called()
 
+    def test_metadata_registration_skips_ledger_mark_for_missing_rows(self):
+        evaluator = self.make_evaluator()
+        missing_row_audio = self.fake_audios(1, prefix="missing-ledger")[0]
+        uploaded_audio = self.fake_audios(1, prefix="uploaded-ledger")[0]
+        self.seed_rows(evaluator, [uploaded_audio], "uploaded")
+        service = MagicMock()
+        evaluator._evaluation_service = service  # type: ignore[assignment]
+
+        evaluator._register_metadata_for_audios([missing_row_audio, uploaded_audio])  # type: ignore[arg-type]
+
+        service.create_evaluation_files.assert_called_once()
+        registered_batch = service.create_evaluation_files.call_args.args[1]
+        self.assertEqual(
+            [audio.remote_object_name for audio in registered_batch],
+            [missing_row_audio.remote_object_name, uploaded_audio.remote_object_name],
+        )
+        assert evaluator._upload_ledger is not None
+        self.assertIsNone(
+            evaluator._upload_ledger.get(
+                evaluator.get_evaluation_id(), missing_row_audio.remote_object_name
+            )
+        )
+        uploaded_row = evaluator._upload_ledger.get(
+            evaluator.get_evaluation_id(), uploaded_audio.remote_object_name
+        )
+        self.assertEqual(uploaded_row.status, "metadata_registered")  # type: ignore[union-attr]
+
     def test_processed_finalization_skips_backend_process_replay(self):
         evaluator = self.make_evaluator()
         audios = self.fake_audios(2, prefix="finalized")

--- a/tests/core/test_upload_ledger.py
+++ b/tests/core/test_upload_ledger.py
@@ -94,6 +94,15 @@ class TestUploadLedger(unittest.TestCase):
         self.assertEqual(row.status, "queued")  # type: ignore[union-attr]
         self.assertNotEqual(row.updated_at, "broken")  # type: ignore[union-attr]
 
+    def test_connection_context_manager_closes_connection(self):
+        ledger, _ = self.make_ledger()
+
+        with ledger._connect() as conn:  # private helper guards Windows file cleanup
+            conn.execute("SELECT 1").fetchone()
+
+        with self.assertRaises(sqlite3.ProgrammingError):
+            conn.execute("SELECT 1")
+
     def test_concurrent_worker_style_updates_are_thread_safe(self):
         ledger, _ = self.make_ledger()
         evaluation_id = "eval-concurrent"

--- a/tests/core/test_upload_ledger.py
+++ b/tests/core/test_upload_ledger.py
@@ -30,7 +30,7 @@ class TestUploadLedger(unittest.TestCase):
         )
         self.assertEqual(queued.status, "queued")
         self.assertEqual(queued_again.status, "queued")
-        self.assertEqual(queued_again.local_path, "/tmp/local.wav")
+        self.assertEqual(queued_again.local_path, os.path.abspath("/tmp/local.wav"))
 
         md5 = ledger.mark_md5_ready(evaluation_id, remote, "abc==", 123)
         md5_again = ledger.mark_md5_ready(evaluation_id, remote, "abc==", 123)

--- a/tests/core/test_upload_ledger.py
+++ b/tests/core/test_upload_ledger.py
@@ -1,0 +1,414 @@
+import os
+import sqlite3
+import tempfile
+import time
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+
+from podonos.core.upload_ledger import (
+    InvalidUploadLedgerTransition,
+    UploadLedger,
+    build_upload_manifest_key,
+)
+
+
+class TestUploadLedger(unittest.TestCase):
+    def make_ledger(self, busy_timeout_ms: int = 1000):
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        path = os.path.join(temp_dir.name, "upload-state.sqlite")
+        return UploadLedger(path, busy_timeout_ms=busy_timeout_ms), path
+
+    def test_idempotent_status_transitions_counts_and_listing(self):
+        ledger, _ = self.make_ledger()
+        evaluation_id = "eval-1"
+        remote = "remote-1.wav"
+
+        queued = ledger.upsert_queued_file(evaluation_id, remote, "/tmp/local.wav")
+        queued_again = ledger.upsert_queued_file(
+            evaluation_id, remote, "/tmp/different-local.wav"
+        )
+        self.assertEqual(queued.status, "queued")
+        self.assertEqual(queued_again.status, "queued")
+        self.assertEqual(queued_again.local_path, "/tmp/local.wav")
+
+        md5 = ledger.mark_md5_ready(evaluation_id, remote, "abc==", 123)
+        md5_again = ledger.mark_md5_ready(evaluation_id, remote, "abc==", 123)
+        self.assertEqual(md5.status, "md5_ready")
+        self.assertEqual(md5_again.status, "md5_ready")
+        self.assertEqual(md5_again.content_md5, "abc==")
+        self.assertEqual(md5_again.file_size, 123)
+
+        uploaded = ledger.mark_uploaded(
+            evaluation_id,
+            remote,
+            "2026-05-22T00:00:00.000Z",
+            "2026-05-22T00:00:01.000Z",
+        )
+        registering = ledger.mark_metadata_registering(evaluation_id, remote)
+        ledger.mark_metadata_registered(evaluation_id, remote)
+        verified = ledger.mark_verified(evaluation_id, remote)
+
+        self.assertEqual(uploaded.status, "uploaded")
+        self.assertEqual(registering.status, "metadata_registering")
+        self.assertEqual(verified.status, "verified")
+        self.assertEqual(ledger.counts_by_status(evaluation_id)["verified"], 1)
+        self.assertEqual(ledger.counts_by_status(evaluation_id)["queued"], 0)
+        self.assertEqual(
+            [row.remote_object_name for row in ledger.list_by_status(evaluation_id, "verified")],
+            [remote],
+        )
+
+    def test_invalid_transition_does_not_advance_row(self):
+        ledger, _ = self.make_ledger()
+        ledger.upsert_queued_file("eval-1", "remote-1.wav", "/tmp/local.wav")
+
+        with self.assertRaises(InvalidUploadLedgerTransition):
+            ledger.mark_uploaded(
+                "eval-1",
+                "remote-1.wav",
+                "2026-05-22T00:00:00.000Z",
+                "2026-05-22T00:00:01.000Z",
+            )
+
+        self.assertEqual(ledger.get("eval-1", "remote-1.wav").status, "queued")  # type: ignore[union-attr]
+
+    def test_transaction_rolls_back_on_failure(self):
+        ledger, _ = self.make_ledger()
+        ledger.upsert_queued_file("eval-1", "remote-1.wav", "/tmp/local.wav")
+
+        with self.assertRaises(RuntimeError):
+            with ledger._transaction() as conn:  # private helper intentionally probed for atomicity
+                conn.execute(
+                    """
+                    UPDATE upload_ledger
+                    SET status = 'uploaded', updated_at = 'broken'
+                    WHERE evaluation_id = ? AND remote_object_name = ?
+                    """,
+                    ("eval-1", "remote-1.wav"),
+                )
+                raise RuntimeError("simulate crash after SQL update")
+
+        row = ledger.get("eval-1", "remote-1.wav")
+        self.assertIsNotNone(row)
+        self.assertEqual(row.status, "queued")  # type: ignore[union-attr]
+        self.assertNotEqual(row.updated_at, "broken")  # type: ignore[union-attr]
+
+    def test_concurrent_worker_style_updates_are_thread_safe(self):
+        ledger, _ = self.make_ledger()
+        evaluation_id = "eval-concurrent"
+        total = 50
+
+        def worker(index: int) -> None:
+            remote = f"remote-{index:03d}.wav"
+            ledger.upsert_queued_file(evaluation_id, remote, f"/tmp/{index}.wav")
+            ledger.mark_md5_ready(evaluation_id, remote, f"md5-{index}", index + 1)
+            ledger.mark_uploaded(
+                evaluation_id,
+                remote,
+                "2026-05-22T00:00:00.000Z",
+                "2026-05-22T00:00:01.000Z",
+            )
+
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            list(executor.map(worker, range(total)))
+
+        counts = ledger.counts_by_status(evaluation_id)
+        self.assertEqual(counts["uploaded"], total)
+        self.assertEqual(len(ledger.list_by_status(evaluation_id, "uploaded")), total)
+
+    def test_busy_timeout_is_finite_when_database_is_locked(self):
+        ledger, path = self.make_ledger(busy_timeout_ms=50)
+        blocker = sqlite3.connect(path, timeout=1, isolation_level=None)
+        try:
+            blocker.execute("BEGIN IMMEDIATE")
+            start = time.monotonic()
+            with self.assertRaises(sqlite3.OperationalError):
+                ledger.upsert_queued_file("eval-locked", "remote.wav", "/tmp/local.wav")
+            elapsed = time.monotonic() - start
+            self.assertLess(elapsed, 1.0)
+        finally:
+            blocker.rollback()
+            blocker.close()
+
+    def test_failure_statuses_store_actionable_errors(self):
+        ledger, _ = self.make_ledger()
+        ledger.upsert_queued_file("eval-1", "remote-1.wav", "/tmp/local.wav")
+        failed_upload = ledger.mark_upload_failed(
+            "eval-1", "remote-1.wav", "RuntimeError", "S3 PUT failed"
+        )
+        self.assertEqual(failed_upload.status, "upload_failed")
+        self.assertEqual(failed_upload.error_type, "RuntimeError")
+        self.assertEqual(failed_upload.error_message, "S3 PUT failed")
+
+        ledger.upsert_queued_file("eval-1", "remote-2.wav", "/tmp/local-2.wav")
+        ledger.mark_md5_ready("eval-1", "remote-2.wav", "abc==", 1)
+        ledger.mark_uploaded(
+            "eval-1",
+            "remote-2.wav",
+            "2026-05-22T00:00:00.000Z",
+            "2026-05-22T00:00:01.000Z",
+        )
+        ledger.mark_metadata_registered("eval-1", "remote-2.wav")
+        failed_verify = ledger.mark_verify_failed(
+            "eval-1", "remote-2.wav", "VERIFY_FAILED", "expected bytes > 0"
+        )
+        self.assertEqual(failed_verify.status, "verify_failed")
+        self.assertEqual(failed_verify.error_type, "VERIFY_FAILED")
+
+    def test_uploaded_row_can_record_and_recover_verification_retry(self):
+        ledger, _ = self.make_ledger()
+        ledger.upsert_queued_file("eval-1", "remote-1.wav", "/tmp/local.wav")
+        ledger.mark_md5_ready("eval-1", "remote-1.wav", "abc==", 123)
+        ledger.mark_uploaded(
+            "eval-1",
+            "remote-1.wav",
+            "2026-05-22T00:00:00.000Z",
+            "2026-05-22T00:00:01.000Z",
+        )
+
+        failed_verify = ledger.mark_verify_failed(
+            "eval-1", "remote-1.wav", "VERIFY_FAILED", "content mismatch"
+        )
+        self.assertEqual(failed_verify.status, "verify_failed")
+
+        ledger.mark_md5_ready("eval-1", "remote-1.wav", "def==", 456)
+        ledger.mark_uploaded(
+            "eval-1",
+            "remote-1.wav",
+            "2026-05-22T00:01:00.000Z",
+            "2026-05-22T00:01:01.000Z",
+        )
+        verified = ledger.mark_verified("eval-1", "remote-1.wav")
+        self.assertEqual(verified.status, "verified")
+
+    def test_failure_messages_are_redacted_before_storage(self):
+        ledger, _ = self.make_ledger()
+        ledger.upsert_queued_file("eval-1", "remote-1.wav", "/tmp/local.wav")
+
+        failed_upload = ledger.mark_upload_failed(
+            "eval-1",
+            "remote-1.wav",
+            "RuntimeError",
+            "failed https://bucket.s3.amazonaws.com/a.wav?X-Amz-Signature=SECRET X-API-KEY=SECRET",
+        )
+
+        self.assertNotIn("SECRET", failed_upload.error_message)
+        self.assertIn("[REDACTED]", failed_upload.error_message)
+
+    def test_local_paths_are_persisted_as_absolute_paths(self):
+        ledger, _ = self.make_ledger()
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        previous_cwd = os.getcwd()
+        try:
+            os.chdir(temp_dir.name)
+            queued = ledger.upsert_queued_file(
+                "eval-1", "remote-1.wav", "relative.wav"
+            )
+            self.assertEqual(queued.local_path, os.path.abspath("relative.wav"))
+            reset = ledger.reset_for_reupload(
+                "eval-1", "remote-1.wav", "other-relative.wav"
+            )
+            self.assertEqual(reset.local_path, os.path.abspath("other-relative.wav"))
+        finally:
+            os.chdir(previous_cwd)
+
+    def test_evaluation_contract_round_trips(self):
+        ledger, _ = self.make_ledger()
+        contract = {
+            "evaluation_id": "eval-1",
+            "eval_type": "NMOS",
+            "eval_language": "en-us",
+            "eval_batch_size": 1,
+            "eval_template_id": None,
+            "use_annotation": False,
+            "use_loudness_normalization": True,
+        }
+
+        ledger.set_evaluation_contract("eval-1", contract)
+
+        self.assertEqual(ledger.get_evaluation_contract("eval-1"), contract)
+
+    def test_finalization_hashes_gate_process_and_session_replay_skips(self):
+        ledger, _ = self.make_ledger()
+
+        ledger.mark_processed("eval-1", 2, request_hash="process-hash-a")
+        ledger.mark_session_json_uploaded("eval-1", session_json_hash="session-hash-a")
+
+        self.assertTrue(ledger.is_processed("eval-1"))
+        self.assertTrue(ledger.is_processed("eval-1", "process-hash-a"))
+        self.assertFalse(ledger.is_processed("eval-1", "process-hash-b"))
+        self.assertTrue(ledger.is_session_json_uploaded("eval-1"))
+        self.assertTrue(ledger.is_session_json_uploaded("eval-1", "session-hash-a"))
+        self.assertFalse(ledger.is_session_json_uploaded("eval-1", "session-hash-b"))
+
+    def test_manifest_key_reorders_without_collapsing_duplicate_occurrences(self):
+        ledger, _ = self.make_ledger()
+        first = ledger.upsert_queued_file(
+            "eval-1",
+            "remote-1.wav",
+            "/tmp/local-1.wav",
+            file_index=0,
+            manifest_key="manifest-1",
+        )
+        same_manifest_different_index = ledger.upsert_queued_file(
+            "eval-1",
+            "remote-2.wav",
+            "/tmp/local-2.wav",
+            file_index=1,
+            manifest_key="manifest-1",
+        )
+
+        self.assertNotEqual(
+            same_manifest_different_index.remote_object_name,
+            first.remote_object_name,
+        )
+
+        third = ledger.upsert_queued_file(
+            "eval-1",
+            "remote-3.wav",
+            "/tmp/local-3.wav",
+            file_index=2,
+            manifest_key="manifest-2",
+        )
+        reordered_third = ledger.upsert_queued_file(
+            "eval-1",
+            "remote-3-reordered.wav",
+            "/tmp/local-3.wav",
+            file_index=0,
+            manifest_key="manifest-2",
+        )
+
+        self.assertEqual(reordered_third.remote_object_name, third.remote_object_name)
+        with self.assertRaises(ValueError):
+            ledger.upsert_queued_file(
+                "eval-1",
+                "remote-4.wav",
+                "/tmp/local-4.wav",
+                file_index=0,
+                manifest_key="different-manifest",
+            )
+
+    def test_build_upload_manifest_key_ignores_remote_object_identity(self):
+        key_a = build_upload_manifest_key(
+            {"uploaded_file_name": "remote-a.wav", "model_tag": "model-a"},
+            "md5",
+            10,
+        )
+        key_b = build_upload_manifest_key(
+            {"uploaded_file_name": "remote-b.wav", "model_tag": "model-a"},
+            "md5",
+            10,
+        )
+
+        self.assertEqual(key_a, key_b)
+
+    def test_legacy_duplicate_file_indexes_are_supported_after_migration(self):
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        path = os.path.join(temp_dir.name, "legacy-state.sqlite")
+        conn = sqlite3.connect(path)
+        try:
+            conn.executescript(
+                """
+                CREATE TABLE upload_ledger (
+                    evaluation_id TEXT NOT NULL,
+                    remote_object_name TEXT NOT NULL,
+                    local_path TEXT NOT NULL,
+                    file_index INTEGER,
+                    status TEXT NOT NULL,
+                    content_md5 TEXT,
+                    file_size INTEGER,
+                    upload_start_at TEXT,
+                    upload_finish_at TEXT,
+                    error_type TEXT,
+                    error_message TEXT,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    PRIMARY KEY (evaluation_id, remote_object_name)
+                );
+                INSERT INTO upload_ledger (
+                    evaluation_id, remote_object_name, local_path, file_index,
+                    status, created_at, updated_at
+                ) VALUES
+                  ('eval-1', 'remote-1.wav', '/tmp/1.wav', 0, 'queued', 'now', 'now'),
+                  ('eval-1', 'remote-2.wav', '/tmp/2.wav', 0, 'queued', 'now', 'now');
+                """
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        ledger = UploadLedger(path)
+
+        with ledger._transaction() as migrated:
+            rows = migrated.execute(
+                """
+                SELECT remote_object_name, file_index
+                FROM upload_ledger
+                WHERE evaluation_id = 'eval-1'
+                ORDER BY remote_object_name
+                """
+            ).fetchall()
+        self.assertEqual([row["file_index"] for row in rows].count(0), 2)
+
+        with ledger._transaction() as migrated:
+            migrated.execute(
+                """
+                INSERT INTO upload_ledger (
+                    evaluation_id,
+                    remote_object_name,
+                    local_path,
+                    file_index,
+                    status,
+                    created_at,
+                    updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    "eval-1",
+                    "remote-3.wav",
+                    "/tmp/3.wav",
+                    0,
+                    "queued",
+                    "now",
+                    "now",
+                ),
+            )
+
+    @unittest.skipIf(os.name == "nt", "POSIX symlink check")
+    def test_ledger_rejects_symlink_path(self):
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        target_path = os.path.join(temp_dir.name, "target.sqlite")
+        symlink_path = os.path.join(temp_dir.name, "upload-state.sqlite")
+        with open(target_path, "wb") as f:
+            f.write(b"")
+        os.symlink(target_path, symlink_path)
+
+        with self.assertRaises(ValueError):
+            UploadLedger(symlink_path)
+
+    @unittest.skipIf(os.name == "nt", "POSIX symlink check")
+    def test_ledger_rejects_symlink_parent_path(self):
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        root = os.path.realpath(temp_dir.name)
+        real_parent = os.path.join(root, "real-parent")
+        symlink_parent = os.path.join(root, "linked-parent")
+        os.makedirs(real_parent)
+        os.symlink(real_parent, symlink_parent)
+
+        with self.assertRaises(ValueError):
+            UploadLedger(os.path.join(symlink_parent, "upload-state.sqlite"))
+
+    @unittest.skipIf(os.name == "nt", "POSIX file mode check")
+    def test_ledger_file_permissions_are_owner_only(self):
+        _, path = self.make_ledger()
+
+        self.assertEqual(os.stat(path).st_mode & 0o777, 0o600)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/core/test_upload_manager.py
+++ b/tests/core/test_upload_manager.py
@@ -1,12 +1,12 @@
 import os
+import time
 import unittest
-
-from datetime import datetime
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from podonos.common.enum import QuestionFileType
 from podonos.core.file import Audio
 from podonos.core.upload_manager import UploadManager
+from podonos.errors import UploadBatchError
 from podonos.service.evaluation_service import EvaluationService
 
 TESTDATA_SPEECH_CH1_MP3 = os.path.join(os.path.dirname(__file__), "speech_ch1.mp3")
@@ -111,6 +111,27 @@ class TestUploadManager(unittest.TestCase):
         self.assertTrue(upload_manager.wait_and_close())
         self.assertEqual(upload_manager._total_uploaded, 2)  # type: ignore
 
+    def test_more_workers_than_files_does_not_hang(self):
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = None
+
+        eval_service = EvaluationService(api_client=MagicMock())
+        upload_manager = UploadManager(evaluation_service=eval_service, max_workers=5)
+        upload_manager._evaluation_service.get_presigned_url = MagicMock(
+            return_value="https://example.com/presigned-url"
+        )  # type: ignore
+        upload_manager._evaluation_service.upload_evaluation_file = MagicMock(
+            return_value=mock_response
+        )  # type: ignore
+
+        audio = create_test_audio(TESTDATA_SPEECH_CH1_MP3, "REMOTE_1")
+        upload_manager.add_file_to_queue("EVALID", audio)
+
+        start = time.monotonic()
+        self.assertTrue(upload_manager.wait_and_close())
+        self.assertLess(time.monotonic() - start, 5)
+        self.assertEqual(upload_manager._total_uploaded, 1)  # type: ignore
+
     def test_md5_calculated_during_upload(self):
         mock_response = MagicMock()
         mock_response.raise_for_status.side_effect = None
@@ -136,6 +157,198 @@ class TestUploadManager(unittest.TestCase):
         self.assertIsNotNone(audio.file_size)
         self.assertEqual(len(audio.content_md5), 24)
         self.assertGreater(audio.file_size, 0)
+
+    def test_upload_reuses_precomputed_integrity(self):
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = None
+
+        eval_service = EvaluationService(api_client=MagicMock())
+        upload_manager = UploadManager(evaluation_service=eval_service, max_workers=1)
+        upload_manager._evaluation_service.get_presigned_url = MagicMock(
+            return_value="https://example.com/presigned-url"
+        )  # type: ignore
+        upload_manager._evaluation_service.upload_evaluation_file = MagicMock(
+            return_value=mock_response
+        )  # type: ignore
+
+        audio = create_test_audio(TESTDATA_SPEECH_TWO_CH1_WAV, "REMOTE_1")
+        audio.set_integrity_info("A" * 24, 123)
+
+        with patch(
+            "podonos.core.upload_manager.calculate_file_md5_base64",
+            side_effect=AssertionError("integrity should be reused"),
+        ) as mock_calculate:
+            upload_manager.add_file_to_queue("EVALID", audio)
+            self.assertTrue(upload_manager.wait_and_close())
+
+        mock_calculate.assert_not_called()
+        self.assertEqual(audio.content_md5, "A" * 24)
+        self.assertEqual(audio.file_size, 123)
+
+    def test_upload_failure_records_error_and_does_not_hang(self):
+        eval_service = EvaluationService(api_client=MagicMock())
+        upload_manager = UploadManager(evaluation_service=eval_service, max_workers=1)
+        upload_manager._evaluation_service.get_presigned_url = MagicMock(
+            return_value="https://example.com/presigned-url"
+        )  # type: ignore
+        upload_manager._evaluation_service.upload_evaluation_file = MagicMock(
+            side_effect=RuntimeError("S3 PUT failed")
+        )  # type: ignore
+
+        audio = create_test_audio(TESTDATA_SPEECH_CH1_MP3, "REMOTE_1")
+        upload_manager.add_file_to_queue("EVALID", audio)
+
+        start = time.monotonic()
+        with self.assertRaises(UploadBatchError) as context:
+            upload_manager.wait_and_close()
+        elapsed = time.monotonic() - start
+
+        self.assertLess(elapsed, 5)
+        self.assertNotIn(os.path.basename(TESTDATA_SPEECH_CH1_MP3), str(context.exception))
+        self.assertNotIn(TESTDATA_SPEECH_CH1_MP3, str(context.exception))
+        self.assertIn("REMOTE_1", str(context.exception))
+        self.assertIn("S3 PUT failed", str(context.exception))
+        self.assertEqual(upload_manager._total_uploaded, 0)  # type: ignore
+        self.assertFalse(upload_manager.wait_and_close())
+
+    def test_upload_failure_redacts_presigned_url_secrets(self):
+        eval_service = EvaluationService(api_client=MagicMock())
+        upload_manager = UploadManager(evaluation_service=eval_service, max_workers=1)
+        upload_manager._evaluation_service.get_presigned_url = MagicMock(
+            return_value="https://example.com/presigned-url"
+        )  # type: ignore
+        upload_manager._evaluation_service.upload_evaluation_file = MagicMock(
+            side_effect=RuntimeError(
+                "PUT failed for https://bucket.s3.amazonaws.com/file.wav"
+                "?X-Amz-Signature=SECRET&X-Amz-Credential=CREDENTIAL "
+                "Authorization: Bearer TOKEN"
+            )
+        )  # type: ignore
+
+        audio = create_test_audio(TESTDATA_SPEECH_CH1_MP3, "REMOTE_1")
+        upload_manager.add_file_to_queue("EVALID", audio)
+
+        with self.assertRaises(UploadBatchError) as context:
+            upload_manager.wait_and_close()
+
+        message = str(context.exception)
+        self.assertNotIn("SECRET", message)
+        self.assertNotIn("CREDENTIAL", message)
+        self.assertNotIn("TOKEN", message)
+        self.assertIn("[REDACTED]", message)
+
+    def test_ledger_failure_warning_is_redacted(self):
+        eval_service = EvaluationService(api_client=MagicMock())
+        ledger = MagicMock()
+        ledger.mark_upload_failed.side_effect = RuntimeError("X-API-KEY=SECRET")
+        upload_manager = UploadManager(
+            evaluation_service=eval_service,
+            max_workers=1,
+            upload_ledger=ledger,
+        )
+        audio = create_test_audio(TESTDATA_SPEECH_CH1_MP3, "REMOTE_LEDGER_ERROR")
+
+        with patch("podonos.core.upload_manager.log.warning") as mock_warning:
+            upload_manager._record_upload_error(  # type: ignore[attr-defined]
+                "EVALID", audio, RuntimeError("upload failed")
+            )
+
+        log_message = mock_warning.call_args.args[0]
+        self.assertNotIn("SECRET", log_message)
+        self.assertIn("[REDACTED]", log_message)
+        with self.assertRaises(UploadBatchError):
+            upload_manager.wait_and_close()
+
+    def test_ledger_md5_failure_fails_upload_before_presigned_url(self):
+        eval_service = EvaluationService(api_client=MagicMock())
+        ledger = MagicMock()
+        ledger.mark_md5_ready.side_effect = RuntimeError(
+            "sqlite write failed X-API-KEY=SECRET"
+        )
+        upload_manager = UploadManager(
+            evaluation_service=eval_service,
+            max_workers=1,
+            upload_ledger=ledger,
+        )
+        upload_manager._evaluation_service.get_presigned_url = MagicMock(
+            return_value="https://example.com/presigned-url"
+        )  # type: ignore
+        upload_manager._evaluation_service.upload_evaluation_file = MagicMock()  # type: ignore
+
+        audio = create_test_audio(TESTDATA_SPEECH_CH1_MP3, "REMOTE_LEDGER_MD5")
+        upload_manager.add_file_to_queue("EVALID", audio)
+
+        with self.assertRaises(UploadBatchError) as context:
+            upload_manager.wait_and_close()
+
+        message = str(context.exception)
+        self.assertIn("Failed to update upload ledger md5_ready", message)
+        self.assertNotIn("SECRET", message)
+        upload_manager._evaluation_service.get_presigned_url.assert_not_called()  # type: ignore[attr-defined]
+        upload_manager._evaluation_service.upload_evaluation_file.assert_not_called()  # type: ignore[attr-defined]
+        ledger.mark_upload_failed.assert_called_once()
+        self.assertEqual(upload_manager._total_uploaded, 0)  # type: ignore
+
+    def test_ledger_uploaded_failure_fails_upload_after_put(self):
+        eval_service = EvaluationService(api_client=MagicMock())
+        ledger = MagicMock()
+        ledger.mark_uploaded.side_effect = RuntimeError(
+            "sqlite write failed X-Amz-Signature=SECRET"
+        )
+        upload_manager = UploadManager(
+            evaluation_service=eval_service,
+            max_workers=1,
+            upload_ledger=ledger,
+        )
+        upload_manager._evaluation_service.get_presigned_url = MagicMock(
+            return_value="https://example.com/presigned-url"
+        )  # type: ignore
+        upload_manager._evaluation_service.upload_evaluation_file = MagicMock(
+            return_value=MagicMock()
+        )  # type: ignore
+
+        audio = create_test_audio(TESTDATA_SPEECH_CH1_MP3, "REMOTE_LEDGER_UPLOADED")
+        upload_manager.add_file_to_queue("EVALID", audio)
+
+        with self.assertRaises(UploadBatchError) as context:
+            upload_manager.wait_and_close()
+
+        message = str(context.exception)
+        self.assertIn("Failed to update upload ledger uploaded", message)
+        self.assertNotIn("SECRET", message)
+        upload_manager._evaluation_service.upload_evaluation_file.assert_called_once()  # type: ignore[attr-defined]
+        ledger.mark_upload_failed.assert_called_once()
+        self.assertEqual(upload_manager._total_uploaded, 0)  # type: ignore
+
+    def test_upload_manager_passes_upload_timeout(self):
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = None
+
+        eval_service = EvaluationService(api_client=MagicMock())
+        upload_manager = UploadManager(
+            evaluation_service=eval_service,
+            max_workers=1,
+            api_timeout=(3, 33),
+            upload_timeout=(11, 222),
+        )
+        upload_manager._evaluation_service.get_presigned_url = MagicMock(
+            return_value="https://example.com/presigned-url"
+        )  # type: ignore
+        upload_manager._evaluation_service.upload_evaluation_file = MagicMock(
+            return_value=mock_response
+        )  # type: ignore
+
+        audio = create_test_audio(TESTDATA_SPEECH_CH1_MP3, "REMOTE_1")
+        upload_manager.add_file_to_queue("EVALID", audio)
+
+        self.assertTrue(upload_manager.wait_and_close())
+        upload_manager._evaluation_service.upload_evaluation_file.assert_called_once()  # type: ignore
+        upload_manager._evaluation_service.get_presigned_url.assert_called_once()  # type: ignore
+        _, presigned_kwargs = upload_manager._evaluation_service.get_presigned_url.call_args  # type: ignore
+        self.assertEqual(presigned_kwargs["timeout"], (3, 33))
+        _, kwargs = upload_manager._evaluation_service.upload_evaluation_file.call_args  # type: ignore
+        self.assertEqual(kwargs["timeout"], (11, 222))
+        self.assertEqual(kwargs["context"]["evaluation_id"], "EVALID")
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_dev_server_e2e.py
+++ b/tests/integration/test_dev_server_e2e.py
@@ -13,9 +13,16 @@ Run examples:
       PODONOS_E2E_FILE_COUNT=3 \
       python -m pytest tests/integration/test_dev_server_e2e.py -q -s
 
+    # Explicit CMOS smoke run. PODONOS_E2E_FILE_COUNT is the total file count,
+    # so it must be even; 2 files means 1 CMOS stimulus/reference pair.
+    PODONOS_E2E=1 PODONOS_E2E_CMOS=1 PODONOS_API_KEY=<KEY> \
+      PODONOS_E2E_FILE_COUNT=2 \
+      python -m pytest tests/integration/test_dev_server_e2e.py::test_dev_server_cmos_upload_verify_with_opt_in_ledger -q -s
+
     # Explicit large-load run. This intentionally uploads 5000 real files to
     # the configured backend, so it has a second opt-in guard and targets only
-    # the load test.
+    # the load test. Set PODONOS_E2E_EVAL_TYPE=CMOS to run the same 5000-file
+    # load path as 2500 CMOS stimulus/reference pairs.
     PODONOS_E2E=1 PODONOS_E2E_LOAD=1 PODONOS_API_KEY=<KEY> \
       PODONOS_E2E_FILE_COUNT=5000 \
       PODONOS_E2E_MAX_UPLOAD_WORKERS=20 \
@@ -27,6 +34,9 @@ Useful env vars:
     PODONOS_API_KEY=<KEY>                 Required API key.
     PODONOS_E2E_BASE_URL=<URL>            Defaults to https://dev.podonosapi.com.
     PODONOS_E2E_FILE_COUNT=<N>            Defaults to 2; capped at 20 for smoke safety.
+                                           For CMOS, this is total files and must be even.
+    PODONOS_E2E_CMOS=1                    Required for the dedicated CMOS smoke test.
+    PODONOS_E2E_EVAL_TYPE=NMOS|CMOS       Defaults to NMOS for the large-load test.
     PODONOS_E2E_LOAD=1                    Required for >20-file load tests.
     PODONOS_E2E_MAX_UPLOAD_WORKERS=<N>    Defaults to 2 for smoke, 20 for load.
     PODONOS_E2E_VERIFY_BATCH_SIZE=<N>     Defaults to 2 for smoke, 500 for load.
@@ -70,6 +80,7 @@ class DevServerSettings:
     verify_timeout: tuple[float, float]
     upload_timeout: tuple[float, float]
     progress_every: int
+    eval_type: str
 
 
 def _truthy_env(name: str) -> bool:
@@ -167,6 +178,9 @@ def dev_server_settings() -> DevServerSettings:
         "PODONOS_E2E_VERIFY_BATCH_SIZE", 500 if load_mode else 2
     )
     progress_every = _int_env("PODONOS_E2E_PROGRESS_EVERY", 500 if load_mode else 100)
+    eval_type = os.getenv("PODONOS_E2E_EVAL_TYPE", "NMOS").strip().upper()
+    if eval_type not in {"NMOS", "CMOS"}:
+        pytest.fail("PODONOS_E2E_EVAL_TYPE must be NMOS or CMOS")
     if max_upload_workers < 1:
         pytest.fail("PODONOS_E2E_MAX_UPLOAD_WORKERS must be >= 1")
     if verify_batch_size < 1 or verify_batch_size > 1000:
@@ -190,6 +204,7 @@ def dev_server_settings() -> DevServerSettings:
         verify_timeout=_timeout_env("PODONOS_E2E_VERIFY_TIMEOUT", (5, 120)),
         upload_timeout=_timeout_env("PODONOS_E2E_UPLOAD_TIMEOUT", (10, 300)),
         progress_every=progress_every,
+        eval_type=eval_type,
     )
 
 
@@ -210,6 +225,11 @@ def _skip_smoke_in_load_mode(settings: DevServerSettings) -> None:
         )
 
 
+def _skip_unless_cmos_enabled() -> None:
+    if not _truthy_env("PODONOS_E2E_CMOS"):
+        pytest.skip("Set PODONOS_E2E_CMOS=1 to run CMOS dev-server E2E tests.")
+
+
 def _add_files(
     etor,
     audio_path: Path,
@@ -227,6 +247,73 @@ def _add_files(
         )
         if (index + 1) % progress_every == 0 or index + 1 == file_count:
             print(f"queued {index + 1}/{file_count} files")
+
+
+def _cmos_pair_count(file_count: int) -> int:
+    if file_count < 2:
+        pytest.fail("CMOS E2E requires PODONOS_E2E_FILE_COUNT >= 2")
+    if file_count % 2 != 0:
+        pytest.fail(
+            "CMOS E2E requires an even PODONOS_E2E_FILE_COUNT because each "
+            "CMOS item uploads one stimulus and one reference file."
+        )
+    return file_count // 2
+
+
+def _add_cmos_file_pairs(
+    etor,
+    audio_path: Path,
+    file_count: int,
+    model_prefix: str,
+    progress_every: int,
+) -> None:
+    pair_count = _cmos_pair_count(file_count)
+    for index in range(pair_count):
+        etor.add_files(
+            file0=File(
+                path=str(audio_path),
+                model_tag=f"{model_prefix}_stimulus_{index % 5}",
+                script="dev server CMOS e2e test stimulus",
+                tags=["dev_e2e", "cmos", "stimulus"],
+            ),
+            file1=File(
+                path=str(audio_path),
+                model_tag=f"{model_prefix}_reference",
+                script="dev server CMOS e2e test reference",
+                tags=["dev_e2e", "cmos", "reference"],
+                is_ref=True,
+            ),
+        )
+        uploaded_count = (index + 1) * 2
+        if uploaded_count % progress_every == 0 or index + 1 == pair_count:
+            print(
+                f"queued {uploaded_count}/{file_count} files "
+                f"({index + 1}/{pair_count} CMOS pairs)"
+            )
+
+
+def _add_files_for_eval_type(
+    etor,
+    settings: DevServerSettings,
+    model_prefix: str,
+) -> None:
+    if settings.eval_type == "CMOS":
+        _add_cmos_file_pairs(
+            etor,
+            settings.audio_path,
+            settings.file_count,
+            model_prefix,
+            settings.progress_every,
+        )
+        return
+
+    _add_files(
+        etor,
+        settings.audio_path,
+        settings.file_count,
+        model_prefix,
+        settings.progress_every,
+    )
 
 
 def test_dev_server_upload_verify_smoke_without_ledger(
@@ -327,6 +414,53 @@ def test_dev_server_upload_verify_with_opt_in_ledger(
     assert "upload_state_path" not in create_dto
 
 
+def test_dev_server_cmos_upload_verify_with_opt_in_ledger(
+    dev_server_settings: DevServerSettings,
+    tmp_path: Path,
+) -> None:
+    """Real dev-server CMOS E2E for opt-in ledger state through upload/verify."""
+    _skip_smoke_in_load_mode(dev_server_settings)
+    _skip_unless_cmos_enabled()
+
+    state_path = tmp_path / "podonos-e2e-cmos-upload-state.sqlite"
+    client = _new_client(dev_server_settings)
+    etor = client.create_evaluator(
+        name=_unique_name("sdk-dev-e2e-cmos-ledger"),
+        desc="SDK dev-server CMOS E2E smoke test with opt-in upload ledger",
+        type="CMOS",
+        lan="en-us",
+        num_eval=1,
+        due_hours=12,
+        auto_start=False,
+        max_upload_workers=dev_server_settings.max_upload_workers,
+        verify_batch_size=dev_server_settings.verify_batch_size,
+        api_timeout=dev_server_settings.api_timeout,
+        verify_timeout=dev_server_settings.verify_timeout,
+        upload_timeout=dev_server_settings.upload_timeout,
+        resume_upload=True,
+        upload_state_path=str(state_path),
+    )
+
+    evaluation_id = etor.get_evaluation_id()
+    _add_cmos_file_pairs(
+        etor,
+        dev_server_settings.audio_path,
+        dev_server_settings.file_count,
+        "dev_cmos",
+        dev_server_settings.progress_every,
+    )
+
+    result = etor.close()
+
+    assert result == {"status": "ok"}
+    assert state_path.exists()
+
+    ledger = UploadLedger(str(state_path))
+    counts = ledger.counts_by_status(evaluation_id)
+    assert counts["verified"] == dev_server_settings.file_count
+    assert sum(counts.values()) == dev_server_settings.file_count
+
+
 def test_dev_server_upload_verify_large_file_count_with_opt_in_ledger(
     dev_server_settings: DevServerSettings,
     tmp_path: Path,
@@ -341,12 +475,16 @@ def test_dev_server_upload_verify_large_file_count_with_opt_in_ledger(
     state_path = tmp_path / "podonos-e2e-large-upload-state.sqlite"
     client = _new_client(dev_server_settings)
     etor = client.create_evaluator(
-        name=_unique_name(f"sdk-dev-e2e-load-{dev_server_settings.file_count}"),
+        name=_unique_name(
+            f"sdk-dev-e2e-{dev_server_settings.eval_type.lower()}-load-"
+            f"{dev_server_settings.file_count}"
+        ),
         desc=(
-            "SDK dev-server large-load E2E with opt-in upload ledger "
+            f"SDK dev-server {dev_server_settings.eval_type} large-load E2E "
+            "with opt-in upload ledger "
             f"({dev_server_settings.file_count} files)"
         ),
-        type="NMOS",
+        type=dev_server_settings.eval_type,
         lan="en-us",
         num_eval=1,
         due_hours=12,
@@ -364,17 +502,16 @@ def test_dev_server_upload_verify_large_file_count_with_opt_in_ledger(
     print(
         "large-load e2e settings: "
         f"evaluation_id={evaluation_id}, "
+        f"eval_type={dev_server_settings.eval_type}, "
         f"file_count={dev_server_settings.file_count}, "
         f"max_upload_workers={dev_server_settings.max_upload_workers}, "
         f"verify_batch_size={dev_server_settings.verify_batch_size}, "
         f"base_url={dev_server_settings.base_url}"
     )
-    _add_files(
+    _add_files_for_eval_type(
         etor,
-        dev_server_settings.audio_path,
-        dev_server_settings.file_count,
+        dev_server_settings,
         "dev_load",
-        dev_server_settings.progress_every,
     )
 
     result = etor.close()

--- a/tests/integration/test_dev_server_e2e.py
+++ b/tests/integration/test_dev_server_e2e.py
@@ -1,0 +1,388 @@
+"""
+Opt-in dev-server E2E tests for real SDK upload/verify flows.
+
+These tests intentionally hit the configured Podonos backend and perform real
+presigned-url uploads, so they are skipped unless explicitly enabled.
+
+Run examples:
+    PODONOS_E2E=1 PODONOS_API_KEY=<KEY> \
+      python -m pytest tests/integration/test_dev_server_e2e.py -q -s
+
+    PODONOS_E2E=1 PODONOS_API_KEY=<KEY> \
+      PODONOS_E2E_BASE_URL=https://dev.podonosapi.com \
+      PODONOS_E2E_FILE_COUNT=3 \
+      python -m pytest tests/integration/test_dev_server_e2e.py -q -s
+
+    # Explicit large-load run. This intentionally uploads 5000 real files to
+    # the configured backend, so it has a second opt-in guard and targets only
+    # the load test.
+    PODONOS_E2E=1 PODONOS_E2E_LOAD=1 PODONOS_API_KEY=<KEY> \
+      PODONOS_E2E_FILE_COUNT=5000 \
+      PODONOS_E2E_MAX_UPLOAD_WORKERS=20 \
+      PODONOS_E2E_VERIFY_BATCH_SIZE=500 \
+      python -m pytest tests/integration/test_dev_server_e2e.py::test_dev_server_upload_verify_large_file_count_with_opt_in_ledger -q -s
+
+Useful env vars:
+    PODONOS_E2E=1                         Required opt-in guard.
+    PODONOS_API_KEY=<KEY>                 Required API key.
+    PODONOS_E2E_BASE_URL=<URL>            Defaults to https://dev.podonosapi.com.
+    PODONOS_E2E_FILE_COUNT=<N>            Defaults to 2; capped at 20 for smoke safety.
+    PODONOS_E2E_LOAD=1                    Required for >20-file load tests.
+    PODONOS_E2E_MAX_UPLOAD_WORKERS=<N>    Defaults to 2 for smoke, 20 for load.
+    PODONOS_E2E_VERIFY_BATCH_SIZE=<N>     Defaults to 2 for smoke, 500 for load.
+    PODONOS_E2E_PROGRESS_EVERY=<N>        Defaults to 100 for smoke, 500 for load.
+    PODONOS_E2E_AUDIO_PATH=/path/a.wav    Optional audio fixture override.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlparse
+
+import pytest
+
+import podonos
+from podonos import File
+from podonos.core.upload_ledger import UploadLedger
+
+
+_DEV_BASE_URL = "https://dev.podonosapi.com"
+_TRUTHY = {"1", "true", "yes", "y", "on"}
+_MAX_SMOKE_FILE_COUNT = 20
+_MAX_LOAD_FILE_COUNT = 10_000
+_DEFAULT_AUDIO_PATH = Path(__file__).resolve().parents[1] / "core" / "speech_ch1.mp3"
+
+
+@dataclass(frozen=True)
+class DevServerSettings:
+    api_key: str
+    base_url: str
+    file_count: int
+    audio_path: Path
+    load_mode: bool
+    max_upload_workers: int
+    verify_batch_size: int
+    api_timeout: tuple[float, float]
+    verify_timeout: tuple[float, float]
+    upload_timeout: tuple[float, float]
+    progress_every: int
+
+
+def _truthy_env(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in _TRUTHY
+
+
+def _int_env(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        pytest.fail(f"{name} must be an integer, got {raw!r}")
+
+
+def _timeout_env(name: str, default: tuple[float, float]) -> tuple[float, float]:
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+
+    parts = [part.strip() for part in raw.split(",")]
+    if len(parts) != 2:
+        pytest.fail(f"{name} must be '<connect>,<read>', got {raw!r}")
+
+    try:
+        timeout = (float(parts[0]), float(parts[1]))
+    except ValueError:
+        pytest.fail(f"{name} must contain numeric timeout values, got {raw!r}")
+
+    if timeout[0] <= 0 or timeout[1] <= 0:
+        pytest.fail(f"{name} timeout values must be positive, got {raw!r}")
+    return timeout
+
+
+def _validate_e2e_base_url(base_url: str) -> str:
+    if _truthy_env("PODONOS_E2E_ALLOW_UNTRUSTED_BASE_URL"):
+        return base_url
+
+    parsed = urlparse(base_url)
+    host = (parsed.hostname or "").lower()
+    if parsed.scheme != "https":
+        pytest.fail("PODONOS_E2E_BASE_URL must use https.")
+    if not (
+        host == "podonosapi.com"
+        or host.endswith(".podonosapi.com")
+        or host == "podonos.com"
+        or host.endswith(".podonos.com")
+    ):
+        pytest.fail(
+            "PODONOS_E2E_BASE_URL must be a Podonos-owned host. "
+            "Set PODONOS_E2E_ALLOW_UNTRUSTED_BASE_URL=1 only for intentional local testing."
+        )
+    return base_url
+
+
+@pytest.fixture(scope="session")
+def dev_server_settings() -> DevServerSettings:
+    if not (_truthy_env("PODONOS_E2E") or _truthy_env("PODONOS_DEV_E2E")):
+        pytest.skip("Set PODONOS_E2E=1 to run real dev-server E2E tests.")
+
+    api_key = os.getenv("PODONOS_API_KEY")
+    if not api_key:
+        pytest.skip("Set PODONOS_API_KEY to run dev-server E2E tests.")
+
+    base_url = (
+        os.getenv("PODONOS_E2E_BASE_URL")
+        or os.getenv("PODONOS_DEV_BASE_URL")
+        or _DEV_BASE_URL
+    )
+    base_url = _validate_e2e_base_url(base_url)
+    load_mode = _truthy_env("PODONOS_E2E_LOAD") or _truthy_env(
+        "PODONOS_E2E_ALLOW_LOAD"
+    )
+    file_count = _int_env("PODONOS_E2E_FILE_COUNT", 2)
+    if file_count < 1:
+        pytest.fail("PODONOS_E2E_FILE_COUNT must be >= 1")
+    if file_count > _MAX_SMOKE_FILE_COUNT and not load_mode:
+        pytest.fail(
+            "PODONOS_E2E_FILE_COUNT must be between 1 and "
+            f"{_MAX_SMOKE_FILE_COUNT} for smoke tests. For a real large-load "
+            "E2E run, add PODONOS_E2E_LOAD=1 and target "
+            "test_dev_server_upload_verify_large_file_count_with_opt_in_ledger."
+        )
+    if file_count > _MAX_LOAD_FILE_COUNT:
+        pytest.fail(
+            f"PODONOS_E2E_FILE_COUNT is capped at {_MAX_LOAD_FILE_COUNT} by this "
+            "test harness. Raise _MAX_LOAD_FILE_COUNT intentionally if needed."
+        )
+
+    max_upload_workers = _int_env(
+        "PODONOS_E2E_MAX_UPLOAD_WORKERS", 20 if load_mode else 2
+    )
+    verify_batch_size = _int_env(
+        "PODONOS_E2E_VERIFY_BATCH_SIZE", 500 if load_mode else 2
+    )
+    progress_every = _int_env("PODONOS_E2E_PROGRESS_EVERY", 500 if load_mode else 100)
+    if max_upload_workers < 1:
+        pytest.fail("PODONOS_E2E_MAX_UPLOAD_WORKERS must be >= 1")
+    if verify_batch_size < 1 or verify_batch_size > 1000:
+        pytest.fail("PODONOS_E2E_VERIFY_BATCH_SIZE must be between 1 and 1000")
+    if progress_every < 1:
+        pytest.fail("PODONOS_E2E_PROGRESS_EVERY must be >= 1")
+
+    audio_path = Path(os.getenv("PODONOS_E2E_AUDIO_PATH", str(_DEFAULT_AUDIO_PATH)))
+    if not audio_path.is_file():
+        pytest.fail(f"E2E audio fixture does not exist: {audio_path}")
+
+    return DevServerSettings(
+        api_key=api_key,
+        base_url=base_url,
+        file_count=file_count,
+        audio_path=audio_path,
+        load_mode=load_mode,
+        max_upload_workers=max_upload_workers,
+        verify_batch_size=verify_batch_size,
+        api_timeout=_timeout_env("PODONOS_E2E_API_TIMEOUT", (5, 30)),
+        verify_timeout=_timeout_env("PODONOS_E2E_VERIFY_TIMEOUT", (5, 120)),
+        upload_timeout=_timeout_env("PODONOS_E2E_UPLOAD_TIMEOUT", (10, 300)),
+        progress_every=progress_every,
+    )
+
+
+def _new_client(settings: DevServerSettings):
+    return podonos.init(api_key=settings.api_key, api_url=settings.base_url)
+
+
+def _unique_name(prefix: str) -> str:
+    stamp = time.strftime("%Y%m%d-%H%M%S")
+    return f"{prefix}-{stamp}-{uuid.uuid4().hex[:8]}"
+
+
+def _skip_smoke_in_load_mode(settings: DevServerSettings) -> None:
+    if settings.load_mode:
+        pytest.skip(
+            "PODONOS_E2E_LOAD=1 is for the dedicated large-load test; "
+            "smoke tests are skipped to avoid duplicate uploads."
+        )
+
+
+def _add_files(
+    etor,
+    audio_path: Path,
+    file_count: int,
+    model_prefix: str,
+    progress_every: int,
+) -> None:
+    for index in range(file_count):
+        etor.add_file(
+            File(
+                path=str(audio_path),
+                model_tag=f"{model_prefix}_{index % 5}",
+                script="dev server e2e test",
+            )
+        )
+        if (index + 1) % progress_every == 0 or index + 1 == file_count:
+            print(f"queued {index + 1}/{file_count} files")
+
+
+def test_dev_server_upload_verify_smoke_without_ledger(
+    dev_server_settings: DevServerSettings,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Real dev-server smoke test: create evaluator, upload files, verify, process."""
+    _skip_smoke_in_load_mode(dev_server_settings)
+
+    # If the SDK accidentally creates the default ledger path when resume is off,
+    # this isolated cwd makes the side effect easy to detect.
+    monkeypatch.chdir(tmp_path)
+
+    client = _new_client(dev_server_settings)
+    etor = client.create_evaluator(
+        name=_unique_name("sdk-dev-e2e-smoke"),
+        desc="SDK dev-server E2E smoke test without upload ledger",
+        type="NMOS",
+        lan="en-us",
+        num_eval=1,
+        due_hours=12,
+        auto_start=False,
+        max_upload_workers=dev_server_settings.max_upload_workers,
+        verify_batch_size=dev_server_settings.verify_batch_size,
+        api_timeout=dev_server_settings.api_timeout,
+        verify_timeout=dev_server_settings.verify_timeout,
+        upload_timeout=dev_server_settings.upload_timeout,
+    )
+
+    evaluation_id = etor.get_evaluation_id()
+    _add_files(
+        etor,
+        dev_server_settings.audio_path,
+        dev_server_settings.file_count,
+        "dev_smoke",
+        dev_server_settings.progress_every,
+    )
+
+    result = etor.close()
+
+    assert result == {"status": "ok"}
+    assert evaluation_id
+    assert not (tmp_path / ".podonos_upload_state.sqlite").exists()
+
+
+def test_dev_server_upload_verify_with_opt_in_ledger(
+    dev_server_settings: DevServerSettings,
+    tmp_path: Path,
+) -> None:
+    """Real dev-server E2E for opt-in ledger state through upload/verify."""
+    _skip_smoke_in_load_mode(dev_server_settings)
+
+    state_path = tmp_path / "podonos-e2e-upload-state.sqlite"
+    client = _new_client(dev_server_settings)
+    etor = client.create_evaluator(
+        name=_unique_name("sdk-dev-e2e-ledger"),
+        desc="SDK dev-server E2E smoke test with opt-in upload ledger",
+        type="NMOS",
+        lan="en-us",
+        num_eval=1,
+        due_hours=12,
+        auto_start=False,
+        max_upload_workers=dev_server_settings.max_upload_workers,
+        verify_batch_size=1,
+        api_timeout=dev_server_settings.api_timeout,
+        verify_timeout=dev_server_settings.verify_timeout,
+        upload_timeout=dev_server_settings.upload_timeout,
+        resume_upload=True,
+        upload_state_path=str(state_path),
+    )
+
+    evaluation_id = etor.get_evaluation_id()
+    _add_files(
+        etor,
+        dev_server_settings.audio_path,
+        dev_server_settings.file_count,
+        "dev_ledger",
+        dev_server_settings.progress_every,
+    )
+
+    result = etor.close()
+
+    assert result == {"status": "ok"}
+    assert state_path.exists()
+
+    ledger = UploadLedger(str(state_path))
+    counts = ledger.counts_by_status(evaluation_id)
+    assert counts["verified"] == dev_server_settings.file_count
+    assert sum(counts.values()) == dev_server_settings.file_count
+
+    # Ledger/resume config must stay SDK-local and not leak into session/backend DTOs.
+    config_dict = etor._eval_config.to_dict()  # type: ignore[attr-defined]
+    create_dto = etor._eval_config.to_create_request_dto()  # type: ignore[attr-defined]
+    assert "resume_upload" not in config_dict
+    assert "upload_state_path" not in config_dict
+    assert "resume_upload" not in create_dto
+    assert "upload_state_path" not in create_dto
+
+
+def test_dev_server_upload_verify_large_file_count_with_opt_in_ledger(
+    dev_server_settings: DevServerSettings,
+    tmp_path: Path,
+) -> None:
+    """Real dev-server large-load E2E, intended for 5000-file verification."""
+    if not dev_server_settings.load_mode:
+        pytest.skip(
+            "Set PODONOS_E2E_LOAD=1 and PODONOS_E2E_FILE_COUNT=5000 to run "
+            "the large-load dev-server E2E test."
+        )
+
+    state_path = tmp_path / "podonos-e2e-large-upload-state.sqlite"
+    client = _new_client(dev_server_settings)
+    etor = client.create_evaluator(
+        name=_unique_name(f"sdk-dev-e2e-load-{dev_server_settings.file_count}"),
+        desc=(
+            "SDK dev-server large-load E2E with opt-in upload ledger "
+            f"({dev_server_settings.file_count} files)"
+        ),
+        type="NMOS",
+        lan="en-us",
+        num_eval=1,
+        due_hours=12,
+        auto_start=False,
+        max_upload_workers=dev_server_settings.max_upload_workers,
+        verify_batch_size=dev_server_settings.verify_batch_size,
+        api_timeout=dev_server_settings.api_timeout,
+        verify_timeout=dev_server_settings.verify_timeout,
+        upload_timeout=dev_server_settings.upload_timeout,
+        resume_upload=True,
+        upload_state_path=str(state_path),
+    )
+
+    evaluation_id = etor.get_evaluation_id()
+    print(
+        "large-load e2e settings: "
+        f"evaluation_id={evaluation_id}, "
+        f"file_count={dev_server_settings.file_count}, "
+        f"max_upload_workers={dev_server_settings.max_upload_workers}, "
+        f"verify_batch_size={dev_server_settings.verify_batch_size}, "
+        f"base_url={dev_server_settings.base_url}"
+    )
+    _add_files(
+        etor,
+        dev_server_settings.audio_path,
+        dev_server_settings.file_count,
+        "dev_load",
+        dev_server_settings.progress_every,
+    )
+
+    result = etor.close()
+
+    assert result == {"status": "ok"}
+    assert state_path.exists()
+
+    ledger = UploadLedger(str(state_path))
+    counts = ledger.counts_by_status(evaluation_id)
+    assert counts["verified"] == dev_server_settings.file_count
+    assert sum(counts.values()) == dev_server_settings.file_count

--- a/tests/service/test_evaluation_service.py
+++ b/tests/service/test_evaluation_service.py
@@ -1,9 +1,12 @@
 from typing import Any, Dict
+import os
+import tempfile
 import unittest
 from unittest.mock import Mock, patch
 from datetime import datetime, timezone
 from uuid import uuid4
 
+from requests import Response
 
 from podonos.common.enum import EvalType, Language, QuestionFileType
 from podonos.common.exception import HTTPError
@@ -136,6 +139,43 @@ class TestEvaluationService(unittest.TestCase):
         self.assertIsNone(evaluation.internal_name)
         self.assertIsNone(evaluation.description)
 
+    def test_get_evaluation_passes_timeout_and_context_when_provided(self):
+        # Given
+        eval_id = str(uuid4())
+        current_time = datetime.now(timezone.utc)
+        expected_response = {
+            "id": eval_id,
+            "title": "Test Evaluation",
+            "internal_name": None,
+            "description": None,
+            "batch_size": 10,
+            "status": "active",
+            "created_time": current_time.isoformat(),
+            "updated_time": current_time.isoformat(),
+        }
+        self.mock_api_client.get.return_value = Mock(
+            status_code=200, json=lambda: expected_response
+        )
+
+        # When
+        evaluation = self.service.get_evaluation(
+            eval_id,
+            timeout=(7, 77),
+            context={"operation": "resume_evaluation"},
+        )
+
+        # Then
+        self.mock_api_client.get.assert_called_once_with(
+            f"evaluations/{eval_id}",
+            timeout=(7, 77),
+            context={
+                "operation": "resume_evaluation",
+                "endpoint": f"evaluations/{eval_id}",
+                "evaluation_id": eval_id,
+            },
+        )
+        self.assertEqual(evaluation.id, eval_id)
+
     def test_should_handle_get_evaluation_failure(self):
         # Given
         eval_id = str(uuid4())
@@ -166,6 +206,27 @@ class TestEvaluationService(unittest.TestCase):
 
         # Then
         self.mock_api_client.put.assert_called_once()
+
+    def test_create_evaluation_files_passes_api_timeout_and_context(self):
+        # Given
+        eval_id = str(uuid4())
+        self.mock_api_client.put.return_value = Mock(status_code=200)
+
+        # When
+        self.service.create_evaluation_files(
+            eval_id,
+            [self.test_audio],
+            timeout=(7, 77),
+            context={"batch_index": 3},
+        )
+
+        # Then
+        self.mock_api_client.put.assert_called_once()
+        _, kwargs = self.mock_api_client.put.call_args
+        self.assertEqual(kwargs["timeout"], (7, 77))
+        self.assertEqual(kwargs["context"]["evaluation_id"], eval_id)
+        self.assertEqual(kwargs["context"]["file_count"], 1)
+        self.assertEqual(kwargs["context"]["batch_index"], 3)
 
     def test_should_handle_create_evaluation_files_failure(self):
         # Given
@@ -269,7 +330,7 @@ class TestEvaluationService(unittest.TestCase):
                     "evaluation_file_id": eval_file_1_id,
                     "file_meta_id": file_meta_1_id,
                     "original_name": "file1.wav",
-                    "original_url": "https://example.com/file1.wav",
+                    "original_url": "https://files.podonos.com/file1.wav",
                     "model_tag": "model1",
                     "tags": ["tag1", "tag2"],
                 },
@@ -277,7 +338,7 @@ class TestEvaluationService(unittest.TestCase):
                     "evaluation_file_id": eval_file_2_id,
                     "file_meta_id": file_meta_2_id,
                     "original_name": "file2.wav",
-                    "original_url": "https://example.com/file2.wav",
+                    "original_url": "https://assets.podonosapi.com/file2.wav",
                     "model_tag": "model2",
                     "tags": ["tag3", "tag4"],
                 },
@@ -310,15 +371,19 @@ class TestEvaluationService(unittest.TestCase):
         mock_open.return_value.__enter__.return_value = mock_file
 
         # When
-        result = self.service.download_evaluation_files_by_evaluation_id(
-            evaluation_id, output_dir
-        )
+        with patch.object(self.service, "_write_download_file") as mock_write_download:
+            result = self.service.download_evaluation_files_by_evaluation_id(
+                evaluation_id, output_dir
+            )
 
         # Then
         self.mock_api_client.get.assert_called_once_with(
             f"evaluation-files/download?evaluation-id={evaluation_id}"
         )
         self.assertEqual(self.mock_api_client.external_get.call_count, 2)
+        for call in self.mock_api_client.external_get.call_args_list:
+            self.assertFalse(call.kwargs["allow_redirects"])
+        self.assertEqual(mock_write_download.call_count, 3)
         self.assertEqual(result, "Files downloaded successfully.")
 
     @patch("os.path.isfile")
@@ -347,9 +412,36 @@ class TestEvaluationService(unittest.TestCase):
 
             # Then
             self.mock_api_client.external_put.assert_called_once_with(
-                url, data=mock_file, headers={"Content-Type": "audio/wav"}
+                url,
+                data=mock_file,
+                headers={"Content-Type": "audio/wav"},
+                timeout=(10, 300),
+                context={"file_count": 1},
             )
             self.assertEqual(response, mock_response)
+            mock_response.raise_for_status.assert_called_once()
+
+    @patch("os.path.isfile")
+    @patch("os.access")
+    def test_upload_evaluation_file_raises_on_presigned_http_error(
+        self, mock_access: Mock, mock_isfile: Mock
+    ):
+        url = "https://presigned-url.com/upload"
+        path = "/tmp/test.wav"
+        mock_isfile.return_value = True
+        mock_access.return_value = True
+
+        with patch("builtins.open", create=True):
+            mock_response = Mock(status_code=403)
+            mock_response.raise_for_status.side_effect = Exception("403 Forbidden")
+            self.mock_api_client.external_put.return_value = mock_response
+
+            with self.assertRaises(HTTPError) as context:
+                self.service.upload_evaluation_file(url, path)
+
+        self.assertIn("Failed to Upload File", str(context.exception))
+        self.assertIn("403 Forbidden", str(context.exception))
+        self.assertNotIn("test.wav", str(context.exception))
 
     def test_should_upload_session_json_successfully(self):
         # Given
@@ -365,9 +457,14 @@ class TestEvaluationService(unittest.TestCase):
 
         # Then
         self.mock_api_client.external_put.assert_called_once_with(
-            url, json_data=data, headers=headers
+            url,
+            json_data=data,
+            headers=headers,
+            timeout=(10, 300),
+            context=None,
         )
         self.assertEqual(response, mock_response)
+        mock_response.raise_for_status.assert_called_once()
 
     def test_should_upload_session_json_without_headers(self):
         # Given
@@ -382,9 +479,27 @@ class TestEvaluationService(unittest.TestCase):
 
         # Then
         self.mock_api_client.external_put.assert_called_once_with(
-            url, json_data=data, headers=None
+            url,
+            json_data=data,
+            headers=None,
+            timeout=(10, 300),
+            context=None,
         )
         self.assertEqual(response, mock_response)
+        mock_response.raise_for_status.assert_called_once()
+
+    def test_put_session_json_raises_on_presigned_http_error(self):
+        url = "https://presigned-url.com/session.json"
+        data: Dict[str, Any] = {"key": "value", "files": []}
+        mock_response = Mock(status_code=403)
+        mock_response.raise_for_status.side_effect = Exception("403 Forbidden")
+        self.mock_api_client.external_put.return_value = mock_response
+
+        with self.assertRaises(HTTPError) as context:
+            self.service.put_session_json(url, data)
+
+        self.assertIn("Failed to Upload JSON", str(context.exception))
+        self.assertIn("403 Forbidden", str(context.exception))
 
     @patch("os.path.isfile")
     @patch("os.access")
@@ -411,6 +526,7 @@ class TestEvaluationService(unittest.TestCase):
             with self.assertRaises(HTTPError) as context:
                 self.service.upload_evaluation_file(url, path)
             self.assertIn("Failed to Upload File", str(context.exception))
+            self.assertNotIn("test.wav", str(context.exception))
 
     def test_should_handle_put_session_json_failure(self):
         # Given
@@ -423,6 +539,47 @@ class TestEvaluationService(unittest.TestCase):
         with self.assertRaises(HTTPError) as context:
             self.service.put_session_json(url, data)
         self.assertIn("Failed to Upload JSON", str(context.exception))
+
+    @patch("podonos.service.evaluation_service.log.debug")
+    def test_put_session_json_does_not_log_or_raise_payload_values(self, mock_debug: Mock):
+        # Given
+        url = "https://presigned-url.com/session.json"
+        data = {
+            "name": "sensitive-eval-name",
+            "files": [
+                {
+                    "group_id": "group-1",
+                    "audios": [
+                        {
+                            "remote_name": "customer/private/audio.wav",
+                            "script": "customer transcript should stay private",
+                            "tag": ["vip-customer-tag"],
+                            "meta_data": {"account": "secret-account"},
+                        }
+                    ],
+                }
+            ],
+        }
+        self.mock_api_client.external_put.side_effect = Exception(
+            "JSON upload failed for "
+            "https://bucket.s3.amazonaws.com/session.json?X-Amz-Signature=SECRET"
+        )
+
+        # When/Then
+        with self.assertRaises(HTTPError) as context:
+            self.service.put_session_json(url, data)
+
+        debug_output = " ".join(str(call.args[0]) for call in mock_debug.call_args_list)
+        error_message = str(context.exception)
+        combined = f"{debug_output} {error_message}"
+        self.assertIn("file_group_count", combined)
+        self.assertIn("audio_count", combined)
+        self.assertNotIn("customer transcript should stay private", combined)
+        self.assertNotIn("customer/private/audio.wav", combined)
+        self.assertNotIn("vip-customer-tag", combined)
+        self.assertNotIn("secret-account", combined)
+        self.assertNotIn("X-Amz-Signature=SECRET", combined)
+        self.assertIn("[REDACTED]", combined)
 
     def test_should_upload_session_json_with_audio_groups(self):
         # Given
@@ -445,8 +602,177 @@ class TestEvaluationService(unittest.TestCase):
         self.service.upload_session_json(evaluation_id, config, audio_groups)  # type: ignore
 
         # Then
-        self.mock_api_client.put.assert_called_once()
-        self.mock_api_client.external_put.assert_called_once()
+        _, presigned_kwargs = self.mock_api_client.put.call_args
+        self.assertEqual(presigned_kwargs["timeout"], config.api_timeout)
+        _, upload_kwargs = self.mock_api_client.external_put.call_args
+        self.assertEqual(upload_kwargs["timeout"], config.upload_timeout)
+        self.assertEqual(upload_kwargs["context"]["evaluation_id"], evaluation_id)
+
+    def test_download_path_helpers_sanitize_model_tag_and_enforce_output_root(self):
+        with tempfile.TemporaryDirectory() as output_dir:
+            safe_segment = self.service._safe_download_path_segment("../../outside")
+            self.assertEqual(safe_segment, "outside")
+
+            safe_path = self.service._safe_output_path(
+                output_dir, safe_segment, "file.wav"
+            )
+            self.assertEqual(
+                os.path.commonpath([os.path.abspath(output_dir), safe_path]),
+                os.path.abspath(output_dir),
+            )
+
+            with self.assertRaises(ValueError):
+                self.service._safe_output_path(output_dir, "..", "outside.wav")
+
+    @unittest.skipIf(os.name == "nt", "POSIX symlink check")
+    def test_write_download_file_rejects_symlink_parent(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_dir = os.path.join(temp_dir, "output")
+            outside_dir = os.path.join(temp_dir, "outside")
+            os.makedirs(output_dir)
+            os.makedirs(outside_dir)
+            os.symlink(outside_dir, os.path.join(output_dir, "model"))
+            file_path = os.path.join(output_dir, "model", "file.wav")
+
+            with self.assertRaises(ValueError):
+                self.service._write_download_file(
+                    file_path, b"audio", output_dir
+                )
+
+            self.assertFalse(os.path.exists(os.path.join(outside_dir, "file.wav")))
+
+    def test_download_errors_are_redacted(self):
+        evaluation_id = str(uuid4())
+        self.mock_api_client.get.side_effect = Exception(
+            "download failed Cookie: session=SECRET "
+            "CloudFront-Signature=SIGNATURE"
+        )
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            with self.assertRaises(HTTPError) as context:
+                self.service.download_evaluation_files_by_evaluation_id(
+                    evaluation_id, output_dir
+                )
+
+        message = str(context.exception)
+        self.assertNotIn("SECRET", message)
+        self.assertNotIn("SIGNATURE", message)
+        self.assertIn("[REDACTED]", message)
+
+    def test_download_rejects_untrusted_original_url_before_sending_cookies(self):
+        evaluation_id = str(uuid4())
+        self.mock_api_client.get.return_value = Mock(
+            status_code=200,
+            json=lambda: {
+                "cookie": {"CloudFront-Signature": "SECRET"},
+                "files": [
+                    {
+                        "evaluation_file_id": "file-id",
+                        "file_meta_id": "meta-id",
+                        "original_name": "file.wav",
+                        "original_url": "http://attacker.example/file.wav",
+                        "model_tag": "model",
+                        "tags": [],
+                    }
+                ],
+            },
+        )
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            with self.assertRaises(HTTPError) as context:
+                self.service.download_evaluation_files_by_evaluation_id(
+                    evaluation_id, output_dir
+                )
+
+        self.mock_api_client.external_get.assert_not_called()
+        self.assertNotIn("SECRET", str(context.exception))
+
+    def test_download_rejects_unowned_cloudfront_host_by_default(self):
+        with self.assertRaises(ValueError):
+            self.service._validate_download_original_url(
+                "https://d111111abcdef8.cloudfront.net/file.wav"
+            )
+
+    def test_download_allows_explicit_configured_host(self):
+        with patch.dict(
+            os.environ,
+            {"PODONOS_DOWNLOAD_ALLOWED_HOSTS": "d111111abcdef8.cloudfront.net"},
+        ):
+            self.assertEqual(
+                self.service._validate_download_original_url(
+                    "https://d111111abcdef8.cloudfront.net/file.wav"
+                ),
+                "https://d111111abcdef8.cloudfront.net/file.wav",
+            )
+
+    def test_download_rejects_untrusted_redirect_without_following(self):
+        evaluation_id = str(uuid4())
+        self.mock_api_client.get.return_value = Mock(
+            status_code=200,
+            json=lambda: {
+                "cookie": {"CloudFront-Signature": "SECRET"},
+                "files": [
+                    {
+                        "evaluation_file_id": "file-id",
+                        "file_meta_id": "meta-id",
+                        "original_name": "file.wav",
+                        "original_url": "https://files.podonos.com/file.wav",
+                        "model_tag": "model",
+                        "tags": [],
+                    }
+                ],
+            },
+        )
+        redirect_response = Mock(
+            status_code=302,
+            headers={"Location": "https://attacker.example/file.wav"},
+        )
+        redirect_response.raise_for_status.side_effect = Exception("302 redirect")
+        self.mock_api_client.external_get.return_value = redirect_response
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            with self.assertRaises(HTTPError):
+                self.service.download_evaluation_files_by_evaluation_id(
+                    evaluation_id, output_dir
+                )
+
+        self.mock_api_client.external_get.assert_called_once()
+        self.assertFalse(self.mock_api_client.external_get.call_args.kwargs["allow_redirects"])
+
+    def test_download_rejects_real_302_response_without_writing_file(self):
+        evaluation_id = str(uuid4())
+        self.mock_api_client.get.return_value = Mock(
+            status_code=200,
+            json=lambda: {
+                "cookie": {"CloudFront-Signature": "SECRET"},
+                "files": [
+                    {
+                        "evaluation_file_id": "file-id",
+                        "file_meta_id": "meta-id",
+                        "original_name": "file.wav",
+                        "original_url": "https://files.podonos.com/file.wav",
+                        "model_tag": "model",
+                        "tags": [],
+                    }
+                ],
+            },
+        )
+        redirect_response = Response()
+        redirect_response.status_code = 302
+        redirect_response.headers["Location"] = "https://attacker.example/file.wav"
+        redirect_response.headers["Content-Type"] = "audio/wav"
+        redirect_response._content = b"redirect body"
+        self.mock_api_client.external_get.return_value = redirect_response
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            with self.assertRaises(HTTPError) as context:
+                self.service.download_evaluation_files_by_evaluation_id(
+                    evaluation_id, output_dir
+                )
+            self.assertEqual(os.listdir(output_dir), [])
+
+        self.assertIn("non-success status", str(context.exception))
+        self.assertNotIn("SECRET", str(context.exception))
 
     def test_should_handle_upload_session_json_failure(self):
         # Given
@@ -479,6 +805,12 @@ class TestEvaluationService(unittest.TestCase):
         self.mock_api_client.put.assert_called_once_with(
             f"evaluations/{evaluation_id}/uploading-presigned-url",
             data={"uploaded_file_name": remote_object_name},
+            timeout=(5, 30),
+            context={
+                "endpoint": f"evaluations/{evaluation_id}/uploading-presigned-url",
+                "evaluation_id": evaluation_id,
+                "file_count": 1,
+            },
         )
         self.assertEqual(result, expected_url)
 
@@ -578,6 +910,12 @@ class TestEvaluationService(unittest.TestCase):
         self.mock_api_client.put.assert_called_once_with(
             f"evaluations/{evaluation_id}/uploading-presigned-url",
             data={"uploaded_file_name": remote_object_name},
+            timeout=(5, 30),
+            context={
+                "endpoint": f"evaluations/{evaluation_id}/uploading-presigned-url",
+                "evaluation_id": evaluation_id,
+                "file_count": 1,
+            },
         )
         self.assertEqual(result, expected_url)
 
@@ -603,6 +941,42 @@ class TestEvaluationService(unittest.TestCase):
         # Then
         self.mock_api_client.patch.assert_called_once_with(
             f"evaluations/{eval_id}/specific-fields", data=payload
+        )
+
+    def test_update_specific_fields_passes_timeout_and_context_when_provided(self):
+        """Test update_specific_fields forwards explicit timeout and retry context"""
+        # Given
+        eval_id = str(uuid4())
+        payload: Dict[str, Any] = {
+            "id": eval_id,
+            "language": "en-us",
+            "build_process": "FILE_UPLOAD",
+            "evaluation_type": "SPEECH_RANKING",
+            "batch_size": 3,
+            "meta_data": {},
+        }
+
+        mock_response = Mock(status_code=200)
+        self.mock_api_client.patch.return_value = mock_response
+
+        # When
+        self.service.update_specific_fields(
+            eval_id,
+            payload,
+            timeout=(9, 99),
+            context={"operation": "ranking_batch_size_resolution"},
+        )
+
+        # Then
+        self.mock_api_client.patch.assert_called_once_with(
+            f"evaluations/{eval_id}/specific-fields",
+            data=payload,
+            timeout=(9, 99),
+            context={
+                "operation": "ranking_batch_size_resolution",
+                "endpoint": f"evaluations/{eval_id}/specific-fields",
+                "evaluation_id": eval_id,
+            },
         )
 
     def test_update_specific_fields_handles_failure(self):
@@ -654,9 +1028,49 @@ class TestEvaluationService(unittest.TestCase):
 
         # Then
         self.mock_api_client.post.assert_called_once()
+        _, kwargs = self.mock_api_client.post.call_args
+        self.assertEqual(kwargs["timeout"], (5, 120))
+        self.assertEqual(kwargs["context"]["endpoint"], f"evaluations/{eval_id}/files/verify")
+        self.assertEqual(kwargs["context"]["evaluation_id"], eval_id)
+        self.assertEqual(kwargs["context"]["file_count"], 1)
         self.assertTrue(result.all_verified)
         self.assertEqual(result.verified_count, 1)
         self.assertEqual(result.failed_count, 0)
+
+    def test_verify_files_passes_custom_timeout_and_context(self):
+        # Given
+        eval_id = str(uuid4())
+        expected_response = {
+            "all_verified": True,
+            "verified_count": 1,
+            "failed_count": 0,
+            "results": [
+                {
+                    "uploaded_file_name": "remote/speech_two_ch1.wav",
+                    "verified": True,
+                    "file_meta_id": str(uuid4()),
+                    "error": None,
+                }
+            ],
+        }
+        self.mock_api_client.post.return_value = Mock(
+            status_code=200, json=lambda: expected_response
+        )
+        self.test_audio.set_integrity_info("AA259hLYqLX6hjV81ve5Cg==", 17920)
+
+        # When
+        self.service.verify_files(
+            eval_id,
+            [self.test_audio],
+            timeout=(7, 180),
+            context={"batch_index": 2, "batch_size": 1},
+        )
+
+        # Then
+        _, kwargs = self.mock_api_client.post.call_args
+        self.assertEqual(kwargs["timeout"], (7, 180))
+        self.assertEqual(kwargs["context"]["batch_index"], 2)
+        self.assertEqual(kwargs["context"]["batch_size"], 1)
 
     def test_verify_files_partial_failure(self):
         # Given
@@ -706,6 +1120,26 @@ class TestEvaluationService(unittest.TestCase):
             self.service.verify_files(eval_id, [self.test_audio])
         self.assertIn("Failed to verify evaluation files", str(context.exception))
 
+    def test_upload_evaluation_file_passes_custom_timeout(self):
+        # Given
+        response = Mock(status_code=200)
+        self.mock_api_client.external_put.return_value = response
+
+        # When
+        result = self.service.upload_evaluation_file(
+            "https://example.com/presigned?X-Amz-Signature=secret",
+            TESTDATA_SPEECH_TWO_CH1_WAV,
+            timeout=(11, 222),
+            context={"evaluation_id": "eval-id"},
+        )
+
+        # Then
+        self.assertEqual(result, response)
+        _, kwargs = self.mock_api_client.external_put.call_args
+        self.assertEqual(kwargs["timeout"], (11, 222))
+        self.assertEqual(kwargs["context"]["evaluation_id"], "eval-id")
+        self.assertEqual(kwargs["context"]["file_count"], 1)
+
     def test_process_files_success(self):
         # Given
         eval_id = str(uuid4())
@@ -742,7 +1176,14 @@ class TestEvaluationService(unittest.TestCase):
 
         # Then
         self.mock_api_client.post.assert_called_once_with(
-            f"evaluations/{eval_id}/files/process", data={}
+            f"evaluations/{eval_id}/files/process",
+            data={},
+            timeout=(5, 30),
+            context={
+                "endpoint": f"evaluations/{eval_id}/files/process",
+                "evaluation_id": eval_id,
+                "file_count": 0,
+            },
         )
         self.assertEqual(result.processing_count, 5)
 


### PR DESCRIPTION
## Context
Large evaluation uploads can be interrupted or retried, so the SDK needs opt-in local resume state that is safe to reuse across process restarts. This change focuses on resumable upload reliability while keeping diagnostics and public artifacts free of caller-provided metadata values.

## Problem
Upload progress previously lived mostly in memory, which made retry and restart behavior fragile around upload, metadata registration, verification, and finalization boundaries. Resume-related errors and retry paths also needed tighter guardrails to avoid duplicate backend side effects, skipped work, or sensitive value exposure in diagnostics.

## Solution
- Add a local SQLite upload ledger for resumable uploads, including status transitions, manifest identity, finalization hashes, path hardening, and contract validation.
- Extend evaluator/client resume flows to hydrate original configuration safely, validate ledger state before backend creation where needed, and handle duplicate files, ranking batch sizes, metadata retries, and finalization skips more defensively.
- Centralize redaction for retry/upload/download errors, harden presigned upload/download response handling, and thread configured timeouts through large-upload paths.
- Add regression coverage for large fake upload flows, resume contract handling, retry logging, download safety, ledger transitions, and opt-in dev-server e2e behavior.

## Test Plan
- [x] `python -m pytest -q`
- [x] `python -m compileall -q podonos tests`
- [x] `git diff --check`
- [x] Targeted ruff checks on changed upload/resume files
- [x] Exact pinned dependency audit subset with `pip-audit --disable-pip --no-deps`

---
Generated with [Podonos Skills](https://github.com/podonos/skills)
