### PR TITLE
feat: add Sinhala, Arabic (Egypt, UAE, Saudi Arabia) to Language enum

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+## 0.40.4
+
+- Add Sinhala (`si-lk`), Arabic - Egypt (`ar-eg`), Arabic - UAE (`ar-ae`), and Arabic - Saudi Arabia (`ar-sa`) to `Language` enum
+
 ## 0.40.3
 
 - Align Hindi locale support with the rest of the language matrix

--- a/podonos/__init__.py
+++ b/podonos/__init__.py
@@ -2,6 +2,6 @@ from .core.file import File
 from .entity.flash_eval import FlashEvalResult
 from .sdk import Podonos, Client
 
-__version__ = "0.40.3"
+__version__ = "0.40.4"
 
 init = Podonos.init

--- a/podonos/common/enum.py
+++ b/podonos/common/enum.py
@@ -198,6 +198,10 @@ class Language(Enum):
     TAMIL = "ta-in"
     KANNADA = "kn-in"
     MALAYALAM = "ml-in"
+    SINHALA = "si-lk"
+    ARABIC_EGYPT = "ar-eg"
+    ARABIC_UAE = "ar-ae"
+    ARABIC_SAUDI_ARABIA = "ar-sa"
     AUDIO = "audio"
 
     @classmethod

--- a/podonos/core/config.py
+++ b/podonos/core/config.py
@@ -219,6 +219,10 @@ class EvalConfig:
             Language.TAMIL.value,
             Language.KANNADA.value,
             Language.MALAYALAM.value,
+            Language.SINHALA.value,
+            Language.ARABIC_EGYPT.value,
+            Language.ARABIC_UAE.value,
+            Language.ARABIC_SAUDI_ARABIA.value,
             Language.AUDIO.value,
         ]:
             raise ValueError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "podonos"
-version = "0.40.3"
+version = "0.40.4"
 description = "Managed evaluation for audio & speech"
 readme = "README.md"
 license = "MIT"

--- a/tests/common/test_enum.py
+++ b/tests/common/test_enum.py
@@ -29,6 +29,10 @@ class TestLanguageEnum(unittest.TestCase):
         self.assertEqual(Language.TAMIL.value, "ta-in")
         self.assertEqual(Language.KANNADA.value, "kn-in")
         self.assertEqual(Language.MALAYALAM.value, "ml-in")
+        self.assertEqual(Language.SINHALA.value, "si-lk")
+        self.assertEqual(Language.ARABIC_EGYPT.value, "ar-eg")
+        self.assertEqual(Language.ARABIC_UAE.value, "ar-ae")
+        self.assertEqual(Language.ARABIC_SAUDI_ARABIA.value, "ar-sa")
         self.assertEqual(Language.AUDIO.value, "audio")
 
     def test_language_from_value_en_in(self):
@@ -202,6 +206,16 @@ class TestEvalTypeEnum(unittest.TestCase):
         self.assertEqual(Language.from_value("ta-in"), Language.TAMIL)
         self.assertEqual(Language.from_value("kn-in"), Language.KANNADA)
         self.assertEqual(Language.from_value("ml-in"), Language.MALAYALAM)
+
+    def test_language_sinhala_arabic(self):
+        self.assertEqual(Language.SINHALA.value, "si-lk")
+        self.assertEqual(Language.ARABIC_EGYPT.value, "ar-eg")
+        self.assertEqual(Language.ARABIC_UAE.value, "ar-ae")
+        self.assertEqual(Language.ARABIC_SAUDI_ARABIA.value, "ar-sa")
+        self.assertEqual(Language.from_value("si-lk"), Language.SINHALA)
+        self.assertEqual(Language.from_value("ar-eg"), Language.ARABIC_EGYPT)
+        self.assertEqual(Language.from_value("ar-ae"), Language.ARABIC_UAE)
+        self.assertEqual(Language.from_value("ar-sa"), Language.ARABIC_SAUDI_ARABIA)
 
 
 class TestAIEvalTypeEnum(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Adds 4 new locales to `Language` enum and `_validate_eval_language` allowlist: Sinhala (`si-lk`), Arabic - Egypt (`ar-eg`), Arabic - UAE (`ar-ae`), Arabic - Saudi Arabia (`ar-sa`).
- Bumps SDK to `0.40.4` (both `pyproject.toml` and `podonos.__version__`).
- Prepends `History.md` entry.
- Unsupported locales continue to raise `ValueError` as today.
- Mirrors diff shape of #311 (Sinhala/Tamil/Kannada/Malayalam).

## Test plan

- [x] `pytest tests/common/test_enum.py tests/core/test_config.py -v` — 43 passed (includes new `test_language_sinhala_arabic`).
- [x] `pytest` full suite — 505 passed, 7 skipped, 0 failed.
- [x] CI green across `test (3.10/3.11/3.12/3.13/3.14)` on Ubuntu/Windows/macOS.
- [x] REPL round-trip: `Language.from_value("si-lk") is Language.SINHALA` etc.