### PR TITLE
feat(upload): register file metadata exactly once across retries and resume

### DIFF
--- a/podonos/core/evaluator.py
+++ b/podonos/core/evaluator.py
@@ -469,7 +469,12 @@ class Evaluator:
         process_request_hash = self._finalization_hash(
             {
                 "evaluation_id": self.get_evaluation_id(),
-                "files": [audio.to_create_file_dict() for audio in all_audios],
+                # Use the stable group ordinal (not the random per-run group id) so
+                # the process-files dedupe hash is byte-stable across a cross-process
+                # resume of comparison/ranking groups; otherwise a resumed run would
+                # miss is_processed() and needlessly re-trigger process_files.
+                # (Single-stimulus group=None is unchanged -> backward compatible.)
+                "files": [self._stable_manifest_contract(audio) for audio in all_audios],
             }
         )
         if self._upload_ledger is not None and self._upload_ledger.is_processed(

--- a/podonos/core/evaluator.py
+++ b/podonos/core/evaluator.py
@@ -12,10 +12,12 @@ from podonos.core.base import log
 from podonos.core.config import EvalConfig
 from podonos.core.file import Audio, AudioGroup, File, FileTransformer, FileValidator
 from podonos.core.upload_ledger import (
+    GROUP_ORDINAL_ATTR,
     UploadLedger,
     UploadLedgerRow,
     build_upload_manifest_hash,
     build_upload_manifest_key,
+    stable_manifest_contract,
 )
 from podonos.core.upload_manager import UploadManager
 from podonos.entity.evaluation import EvaluationEntity
@@ -283,6 +285,7 @@ class Evaluator:
         file = self._file_validator.validate_file(file)
         audio_group = self._file_transformer.transform_into_audio_group([file])
         self._ordered_file_groups.append(audio_group)
+        self._assign_group_ordinal(audio_group)
         self._upload_one_file(
             evaluation_id=self.get_evaluation_id(), audio=audio_group.audios[0]
         )
@@ -335,6 +338,7 @@ class Evaluator:
         files = self._file_validator.validate_files([file0, file1, file2])
         audio_group = self._file_transformer.transform_into_audio_group(files)
         self._ordered_file_groups.append(audio_group)
+        self._assign_group_ordinal(audio_group)
         for audio in audio_group.audios:
             self._upload_one_file(evaluation_id=self.get_evaluation_id(), audio=audio)
 
@@ -355,6 +359,7 @@ class Evaluator:
         validated_files = self._file_validator.validate_files(files)
         audio_group = self._file_transformer.transform_into_audio_group(validated_files)
         self._ordered_file_groups.append(audio_group)
+        self._assign_group_ordinal(audio_group)
         if self._eval_config.resume_upload:
             try:
                 self._update_ranking_batch_size_before_upload()
@@ -560,6 +565,10 @@ class Evaluator:
             return None
         return self._upload_ledger.get(self.get_evaluation_id(), audio.remote_object_name)
 
+    def _is_metadata_acked(self, audio: Audio) -> bool:
+        row = self._get_ledger_row(audio)
+        return bool(row is not None and getattr(row, "metadata_acked", False))
+
     def _should_skip_upload(self, audio: Audio) -> bool:
         if self._upload_ledger is None:
             return False
@@ -575,7 +584,16 @@ class Evaluator:
         )
         self._apply_ledger_remote_identity(audio, row)
         if not self._ledger_row_matches_local_file(audio, row):
-            if row.status in {"metadata_registering", "metadata_registered", "verified"}:
+            # Fail closed for any row whose metadata was already POSTed to the
+            # backend (registered/verified status OR the monotonic ack): resetting
+            # it for re-upload would keep metadata_acked=True, so the changed
+            # metadata would be skipped by the c2 guard and never re-registered,
+            # leaving stale backend metadata. A genuine verify-failure re-upload
+            # does NOT reach here (the contract is unchanged, so the row matches).
+            if (
+                row.status in {"metadata_registering", "metadata_registered", "verified"}
+                or getattr(row, "metadata_acked", False)
+            ):
                 raise ValueError(
                     "Upload ledger row does not match the current local file for "
                     "the current upload item. Start a fresh evaluation or remove the stale "
@@ -601,6 +619,69 @@ class Evaluator:
         self._next_file_index += 1
         return file_index
 
+    def _assign_group_ordinal(self, audio_group: AudioGroup) -> None:
+        """Stamp every audio in a freshly appended group with its stable positional
+        ordinal (the group's index in `_ordered_file_groups`). This is the single
+        source of truth shared by the manifest key, the manifest hash, and the c3
+        idempotency key, and it is what makes resume identity stable across a process
+        restart (a random per-run group_id would not be)."""
+        ordinal = len(self._ordered_file_groups) - 1
+        for audio in audio_group.audios:
+            setattr(audio, GROUP_ORDINAL_ATTR, ordinal)
+
+    def _resolve_group_ordinal(self, audio: Audio) -> Optional[int]:
+        """Return the audio's stable group ordinal.
+
+        Fast path: the value stamped at queue time by `_assign_group_ordinal`.
+        Fallback (tests that inject `_ordered_file_groups` without going through
+        `add_*`): a cached identity map over the ordered groups. Returns None only
+        when the audio belongs to no known group, in which case callers keep the raw
+        identity rather than substituting a wrong ordinal.
+        """
+        existing = getattr(audio, GROUP_ORDINAL_ATTR, None)
+        if existing is not None:
+            return int(existing)
+        ordinal = self._group_ordinal_map().get(id(audio))
+        if ordinal is not None:
+            setattr(audio, GROUP_ORDINAL_ATTR, ordinal)
+        return ordinal
+
+    def _group_ordinal_map(self) -> Dict[int, int]:
+        groups = self._ordered_file_groups
+        cache = getattr(self, "_group_ordinal_cache", None)
+        if cache is not None and cache[0] is groups and cache[1] == len(groups):
+            return cache[2]
+        mapping: Dict[int, int] = {}
+        for ordinal, group in enumerate(groups):
+            for audio in group.audios:
+                mapping[id(audio)] = ordinal
+        self._group_ordinal_cache = (groups, len(groups), mapping)
+        return mapping
+
+    def _stable_manifest_contract(self, audio: Audio) -> Dict[str, Any]:
+        return stable_manifest_contract(
+            audio.to_create_file_dict(), self._resolve_group_ordinal(audio)
+        )
+
+    def _idempotency_key(self, audio: Audio) -> str:
+        """Stable per-row idempotency key for create_evaluation_files (c3, shape b).
+
+        Derived from stable identity (evaluation_id + group_ordinal + order_in_group),
+        NOT the random remote_object_name, so it survives a re-upload and lets the
+        backend collapse a retried/lost-response POST.
+
+        If the ordinal cannot be resolved (a degenerate path where the audio belongs
+        to no known group), fall back to the row's remote_object_name so DISTINCT
+        files never collapse onto the same key (`:0:` aliasing would make the backend
+        merge separate slots into one row — the original under-count symptom). The
+        fallback is distinct-per-file rather than stable-across-reupload, which is
+        the correct trade for a case that should not occur in production.
+        """
+        ordinal = self._resolve_group_ordinal(audio)
+        if ordinal is None:
+            return f"{self.get_evaluation_id()}:r-{audio.remote_object_name}"
+        return f"{self.get_evaluation_id()}:{ordinal}:{audio.order_in_group}"
+
     def _apply_ledger_remote_identity(
         self, audio: Audio, row: UploadLedgerRow
     ) -> None:
@@ -612,7 +693,7 @@ class Evaluator:
         content_md5, file_size = calculate_file_md5_base64(audio.path)
         audio.set_integrity_info(content_md5, file_size)
         return build_upload_manifest_key(
-            audio.to_create_file_dict(), content_md5, file_size
+            self._stable_manifest_contract(audio), content_md5, file_size
         )
 
     def _ledger_row_matches_local_file(
@@ -631,7 +712,7 @@ class Evaluator:
         audio.set_integrity_info(content_md5, file_size)
         if row.status != "upload_failed":
             manifest_hash = build_upload_manifest_hash(
-                audio.to_create_file_dict(), content_md5, file_size
+                self._stable_manifest_contract(audio), content_md5, file_size
             )
             if row.manifest_hash != manifest_hash:
                 return False
@@ -667,6 +748,13 @@ class Evaluator:
             self._hydrate_audio_from_ledger(audio, row)
             if row.status in {"metadata_registering", "metadata_registered", "verify_failed"}:
                 audios_for_verification.append(audio)
+            elif row.status == "uploaded" and getattr(row, "metadata_acked", False):
+                # c1 re-uploads an already-registered (acked) row and skips
+                # re-registration, expecting the in-run re-verify loop to verify it.
+                # If the process died before that loop, on resume the row is
+                # uploaded+acked: the c2 guard skips registration, so it must be
+                # routed back to verification here or it would finalize unverified.
+                audios_for_verification.append(audio)
         return audios_for_verification
 
     def _register_metadata_for_audios(self, audios: List[Audio]) -> None:
@@ -683,23 +771,34 @@ class Evaluator:
                         "batch_start": i,
                         "total_files": len(audios),
                     },
+                    idempotency_keys=[self._idempotency_key(a) for a in batch],
                 )
             return
 
+        skipped_acked = 0
         for i in range(0, len(audios), 500):
             batch = audios[i : i + 500]
             batch_to_register: List[Audio] = []
+            idempotency_keys: List[str] = []
             ledger_batch_to_mark_registered: List[Audio] = []
             for audio in batch:
                 row = self._get_ledger_row(audio)
+                # c2 guard: never re-POST an already-acknowledged registration,
+                # regardless of the row's current status. This is the single
+                # correctness net at the only caller of create_evaluation_files.
+                if row is not None and getattr(row, "metadata_acked", False):
+                    skipped_acked += 1
+                    continue
                 if row is None:
                     batch_to_register.append(audio)
+                    idempotency_keys.append(self._idempotency_key(audio))
                     continue
                 if row.status == "uploaded":
                     self._upload_ledger.mark_metadata_registering(
                         self.get_evaluation_id(), audio.remote_object_name
                     )
                     batch_to_register.append(audio)
+                    idempotency_keys.append(self._idempotency_key(audio))
                     ledger_batch_to_mark_registered.append(audio)
 
             if not batch_to_register:
@@ -716,6 +815,7 @@ class Evaluator:
                         "batch_start": i,
                         "total_files": len(audios),
                     },
+                    idempotency_keys=idempotency_keys,
                 )
             except Exception as exc:
                 for audio in ledger_batch_to_mark_registered:
@@ -736,6 +836,12 @@ class Evaluator:
                 self._upload_ledger.mark_metadata_registered(
                     self.get_evaluation_id(), audio.remote_object_name
                 )
+
+        if skipped_acked:
+            log.info(
+                f"Skipped metadata registration for {skipped_acked} "
+                "already-acked row(s)."
+            )
 
     def _persist_verify_results(
         self, evaluation_id: str, results: List[FileVerificationResult]
@@ -835,7 +941,19 @@ class Evaluator:
             retry_manager.add_file_to_queue(self.get_evaluation_id(), audio)
 
         retry_manager.wait_and_close()
-        self._register_metadata_for_audios(upload_retry_audios)
+        # c1: a verify failure on an already-registered row means the S3 object was
+        # bad, not the metadata. Re-upload + re-verify only; do NOT re-POST
+        # create_evaluation_files for rows whose registration was already acked.
+        # Those fall through to the caller's existing re-verify loop. (c2's guard in
+        # _register_metadata_for_audios is the correctness net; this skip avoids the
+        # needless registration attempt and the mark_metadata_registering churn.)
+        audios_to_register = [
+            audio
+            for audio in upload_retry_audios
+            if not self._is_metadata_acked(audio)
+        ]
+        if audios_to_register:
+            self._register_metadata_for_audios(audios_to_register)
 
     def _find_original_name(self, remote_object_name: str) -> str:
         for group in self._ordered_file_groups:

--- a/podonos/core/evaluator.py
+++ b/podonos/core/evaluator.py
@@ -672,15 +672,25 @@ class Evaluator:
         """Stable per-row idempotency key for create_evaluation_files (c3, shape b).
 
         Derived from stable identity (evaluation_id + group_ordinal + order_in_group),
-        NOT the random remote_object_name, so it survives a re-upload and lets the
-        backend collapse a retried/lost-response POST.
+        NOT the random remote_object_name, so it stays byte-identical across an
+        HTTP-transport retry of the same request.
+
+        Forward-compat only: the backend currently IGNORES this field (DTO uses
+        Pydantic extra="ignore") and de-duplicates on the slot
+        (file_meta_id, group, order) under pg_advisory_xact_lock(evaluation_id);
+        file_meta_id derives from remote_object_name. So duplicate POSTs are already
+        collapsed backend-side via the slot as long as remote_object_name + group +
+        order_in_group stay byte-identical on any re-POST (guaranteed by the reused
+        request body on HTTP-retry and the stable manifest identity). Note the key
+        formula is position-based and omits remote_object_name; if the backend ever
+        starts honoring the key, align this formula to the slot (include
+        remote_object_name) so the two dedup dimensions cannot disagree.
 
         If the ordinal cannot be resolved (a degenerate path where the audio belongs
         to no known group), fall back to the row's remote_object_name so DISTINCT
-        files never collapse onto the same key (`:0:` aliasing would make the backend
-        merge separate slots into one row — the original under-count symptom). The
-        fallback is distinct-per-file rather than stable-across-reupload, which is
-        the correct trade for a case that should not occur in production.
+        files never collapse onto the same key (`:0:` aliasing). The fallback is
+        distinct-per-file rather than stable-across-reupload, which is the correct
+        trade for a case that should not occur in production.
         """
         ordinal = self._resolve_group_ordinal(audio)
         if ordinal is None:

--- a/podonos/core/evaluator.py
+++ b/podonos/core/evaluator.py
@@ -967,12 +967,21 @@ class Evaluator:
             retry_manager.add_file_to_queue(self.get_evaluation_id(), audio)
 
         retry_manager.wait_and_close()
-        # c1: a verify failure on an already-registered row means the S3 object was
-        # bad, not the metadata. Re-upload + re-verify only; do NOT re-POST
-        # create_evaluation_files for rows whose registration was already acked.
-        # Those fall through to the caller's existing re-verify loop. (c2's guard in
-        # _register_metadata_for_audios is the correctness net; this skip avoids the
-        # needless registration attempt and the mark_metadata_registering churn.)
+        # c1 — decouple verify-retry from registration: a verify failure means the S3
+        # object was bad, not the metadata, so re-upload + re-verify ONLY and never
+        # re-POST create_evaluation_files for a file that was already registered. This
+        # removes the duplicate-evaluation_file trigger, and it must hold in BOTH
+        # configurations:
+        #   - No ledger (the DEFAULT, resume_upload=False): there is no metadata_acked
+        #     guard at all, but EVERY file reaching the verify-retry was already
+        #     registered in the main path (_get_audios_needing_metadata_registration
+        #     returns all audios when there is no ledger, and a failed registration
+        #     would have raised before verify ran). So none of them may be
+        #     re-registered — re-upload + re-verify only.
+        #   - Ledger on: skip rows whose registration was already acked; the c2 guard
+        #     in _register_metadata_for_audios is the correctness net for the rest.
+        if self._upload_ledger is None:
+            return
         audios_to_register = [
             audio
             for audio in upload_retry_audios

--- a/podonos/core/evaluator.py
+++ b/podonos/core/evaluator.py
@@ -678,13 +678,24 @@ class Evaluator:
         Forward-compat only: the backend currently IGNORES this field (DTO uses
         Pydantic extra="ignore") and de-duplicates on the slot
         (file_meta_id, group, order) under pg_advisory_xact_lock(evaluation_id);
-        file_meta_id derives from remote_object_name. So duplicate POSTs are already
-        collapsed backend-side via the slot as long as remote_object_name + group +
-        order_in_group stay byte-identical on any re-POST (guaranteed by the reused
-        request body on HTTP-retry and the stable manifest identity). Note the key
-        formula is position-based and omits remote_object_name; if the backend ever
-        starts honoring the key, align this formula to the slot (include
-        remote_object_name) so the two dedup dimensions cannot disagree.
+        file_meta_id derives from remote_object_name and `group` is the RAW wire
+        group (the manifest ordinal substitution is local-only and does not change
+        the wire payload). Duplicate-POST coverage today, without the key:
+          - HTTP-transport retry: the reused request body keeps the whole slot
+            byte-identical, so the backend collapses it.
+          - cross-process resume re-POST: re-registration is gated behind a verify
+            FAILURE (an already-acked row is skipped by the c2 guard; a
+            metadata_registering row is verified first and only re-registered if
+            verify fails, i.e. the original POST never persisted), so there is no
+            committed original row to duplicate. NOTE the wire group_id regenerates
+            per run, so for a comparison group the slot is NOT stable across resume;
+            the only residual gap is the narrow "original committed but verify
+            falsely failed" edge, which this key (stable across group_id regen)
+            would close once the backend honors it.
+        The key formula is position-based and omits remote_object_name; if the
+        backend ever starts honoring the key, align it to the slot (include
+        remote_object_name, and/or persist a stable group id) so the two dedup
+        dimensions cannot disagree.
 
         If the ordinal cannot be resolved (a degenerate path where the audio belongs
         to no known group), fall back to the row's remote_object_name so DISTINCT

--- a/podonos/core/upload_ledger.py
+++ b/podonos/core/upload_ledger.py
@@ -76,6 +76,40 @@ def build_upload_manifest_hash(
     return hashlib.sha256(encoded).hexdigest()
 
 
+# Transient Audio attribute carrying the resolved stable group ordinal.
+GROUP_ORDINAL_ATTR = "_podonos_group_ordinal"
+
+
+def stable_manifest_contract(
+    file_contract: Dict[str, Any], group_ordinal: Optional[int]
+) -> Dict[str, Any]:
+    """Return a copy of ``file_contract`` with the random per-run ``group`` replaced
+    by the stable positional ``group_ordinal``, so manifest identity (key and hash)
+    is byte-stable across a cross-process resume.
+
+    Substitution happens ONLY when the contract carries a NON-NULL ``group`` (the
+    random per-run ``group_id`` minted for comparison groups) AND an ordinal is
+    resolved. It is deliberately skipped when:
+      - ``group`` is ``None`` (single-stimulus: NMOS/QMOS/P808/CUSTOM_SINGLE). A
+        ``None`` group is already a stable constant, so substituting it to ``0``
+        would gratuitously change the manifest identity and break BACKWARD
+        COMPATIBILITY with ledgers persisted by prior SDK versions (whose stored
+        key/hash used ``group=None``). Leaving it untouched keeps those resumes
+        working while losing nothing (there was no instability to fix).
+      - the ordinal is unresolved (``None``) or the contract has no ``group`` key
+        (minimal test doubles): keep the raw identity rather than alias to a wrong
+        ordinal.
+    The same ordinal is shared by the manifest key, the manifest hash, and the c3
+    idempotency key, so all three consumers agree (see evaluator/upload_manager).
+    """
+
+    if group_ordinal is None or file_contract.get("group") is None:
+        return dict(file_contract)
+    contract = dict(file_contract)
+    contract["group"] = group_ordinal
+    return contract
+
+
 @dataclass(frozen=True)
 class UploadLedgerRow:
     evaluation_id: str
@@ -93,6 +127,12 @@ class UploadLedgerRow:
     upload_finish_at: Optional[str] = None
     error_type: Optional[str] = None
     error_message: Optional[str] = None
+    # Monotonic "create_evaluation_files POST acknowledged" flag. Set true once on a
+    # 2xx registration (see mark_metadata_registered) and NEVER reset by any later
+    # status transition. Kept distinct from the mutable `status` precisely so the
+    # "already POSTed" fact survives verify_failed -> uploaded churn and resume.
+    # MUST be the last field (defaulted) of this frozen dataclass.
+    metadata_acked: bool = False
 
 
 class InvalidUploadLedgerTransition(ValueError):
@@ -250,6 +290,8 @@ class UploadLedger:
             remote_object_name,
             target_status="queued",
             allowed_from=tuple(LEDGER_STATUSES),
+            # NOTE: metadata_acked is intentionally NOT in this updates dict. It is
+            # monotonic — a re-upload must never clear the "already POSTed" fact.
             updates={
                 "local_path": local_path,
                 "content_md5": None,
@@ -334,7 +376,13 @@ class UploadLedger:
                 "metadata_registered",
                 "verify_failed",
             ),
-            updates={"error_type": None, "error_message": None},
+            # Set the monotonic ack atomically with the status flip: a successful
+            # create_evaluation_files POST is the durable "already registered" fact.
+            updates={
+                "error_type": None,
+                "error_message": None,
+                "metadata_acked": 1,
+            },
         )
 
     def mark_metadata_registering(
@@ -679,6 +727,7 @@ class UploadLedger:
                         upload_finish_at TEXT,
                         error_type TEXT,
                         error_message TEXT,
+                        metadata_acked INTEGER NOT NULL DEFAULT 0,
                         created_at TEXT NOT NULL,
                         updated_at TEXT NOT NULL,
                         PRIMARY KEY (evaluation_id, remote_object_name),
@@ -716,6 +765,9 @@ class UploadLedger:
                 self._ensure_column(conn, "file_index", "INTEGER")
                 self._ensure_column(conn, "manifest_key", "TEXT")
                 self._ensure_column(conn, "manifest_hash", "TEXT")
+                self._ensure_column(
+                    conn, "metadata_acked", "INTEGER NOT NULL DEFAULT 0"
+                )
                 self._ensure_table_column(
                     conn,
                     "upload_ledger_finalization",
@@ -730,6 +782,7 @@ class UploadLedger:
                 )
                 self._migrate_status_check_if_needed(conn)
                 self._deduplicate_file_indexes(conn)
+                self._backfill_metadata_acked(conn)
                 conn.execute(
                     """
                     CREATE INDEX IF NOT EXISTS idx_upload_ledger_status
@@ -905,6 +958,7 @@ class UploadLedger:
                 upload_finish_at TEXT,
                 error_type TEXT,
                 error_message TEXT,
+                metadata_acked INTEGER NOT NULL DEFAULT 0,
                 created_at TEXT NOT NULL,
                 updated_at TEXT NOT NULL,
                 PRIMARY KEY (evaluation_id, remote_object_name),
@@ -933,6 +987,7 @@ class UploadLedger:
                 upload_finish_at,
                 error_type,
                 error_message,
+                metadata_acked,
                 created_at,
                 updated_at
             )
@@ -957,6 +1012,14 @@ class UploadLedger:
                 upload_finish_at,
                 error_type,
                 error_message,
+                CASE
+                    WHEN EXISTS (
+                        SELECT 1 FROM pragma_table_info('upload_ledger_old')
+                        WHERE name = 'metadata_acked'
+                    )
+                    THEN metadata_acked
+                    ELSE 0
+                END,
                 created_at,
                 updated_at
             FROM upload_ledger_old;
@@ -968,6 +1031,28 @@ class UploadLedger:
         # File order is no longer identity. Keep legacy duplicate indexes as
         # diagnostics instead of mutating them for a uniqueness constraint.
         return
+
+    def _backfill_metadata_acked(self, conn: sqlite3.Connection) -> None:
+        """Backfill the monotonic ack for rows that were provably already POSTed.
+
+        A row at status `metadata_registered` or `verified` had a successful
+        `create_evaluation_files` POST before this column existed (e.g. a ledger
+        written by a pre-fix SDK then resumed by a fixed one), so it must be
+        treated as acked to protect the in-flight cross-version resume. The
+        `metadata_acked = 0` predicate makes this UPDATE a no-op on already
+        migrated databases (idempotent on every open). `metadata_registering`
+        rows are intentionally NOT backfilled: they were not confirmed POSTed,
+        and are protected on resume by the c3 idempotency key + backend dedup.
+        """
+
+        conn.execute(
+            """
+            UPDATE upload_ledger
+            SET metadata_acked = 1
+            WHERE metadata_acked = 0
+              AND status IN ('metadata_registered', 'verified')
+            """
+        )
 
     def _harden_permissions(self) -> None:
         if os.name == "nt" or not os.path.exists(self.path):
@@ -1015,6 +1100,7 @@ class UploadLedger:
             upload_finish_at=row["upload_finish_at"],
             error_type=row["error_type"],
             error_message=row["error_message"],
+            metadata_acked=bool(row["metadata_acked"]),
             created_at=str(row["created_at"]),
             updated_at=str(row["updated_at"]),
         )

--- a/podonos/core/upload_manager.py
+++ b/podonos/core/upload_manager.py
@@ -22,9 +22,11 @@ from podonos.common.util import calculate_file_md5_base64
 from podonos.common.validator import Rules, validate_args
 from podonos.errors.error import UploadBatchError, UploadFailure
 from podonos.core.upload_ledger import (
+    GROUP_ORDINAL_ATTR,
     UploadLedger,
     build_upload_manifest_hash,
     build_upload_manifest_key,
+    stable_manifest_contract,
 )
 
 if TYPE_CHECKING:
@@ -305,11 +307,17 @@ class UploadManager:
     ) -> None:
         if self._upload_ledger is None:
             return
+        # Use the stable group ordinal stamped onto the audio by the evaluator before
+        # it was queued, so the persisted manifest key/hash match the evaluator's
+        # queue-time key (the random per-run group would diverge and break resume).
+        stable_contract = stable_manifest_contract(
+            audio.to_create_file_dict(), getattr(audio, GROUP_ORDINAL_ATTR, None)
+        )
         manifest_hash = build_upload_manifest_hash(
-            audio.to_create_file_dict(), content_md5, file_size
+            stable_contract, content_md5, file_size
         )
         manifest_key = build_upload_manifest_key(
-            audio.to_create_file_dict(), content_md5, file_size
+            stable_contract, content_md5, file_size
         )
         try:
             self._upload_ledger.mark_md5_ready(

--- a/podonos/service/evaluation_service.py
+++ b/podonos/service/evaluation_service.py
@@ -217,11 +217,14 @@ class EvaluationService:
         """Build the create_evaluation_files request body (c3, shape b).
 
         When idempotency_keys is provided, a per-row `idempotency_key` is zipped into
-        each file dict so the backend can collapse a retried/lost-response POST. The
-        same `data` dict is reused across the HTTP-transport retry in
-        ``api._execute_with_retry`` (the closure captures one body), so the key is
-        byte-stable across retries for free. When None (e.g. callers that do not
-        compute keys), the body is built exactly as before.
+        each file dict. This is forward-compat metadata: the backend currently
+        ignores the field (DTO uses Pydantic extra="ignore", so there is no
+        validation error) and de-duplicates retried/lost-response POSTs on the slot
+        (file_meta_id, group, order) under an advisory lock. The same `data` dict is
+        reused across the HTTP-transport retry in ``api._execute_with_retry`` (the
+        closure captures one body), so the key is byte-stable across retries for
+        free. When None (e.g. callers that do not compute keys), the body is built
+        exactly as before.
         """
         if idempotency_keys is None:
             return [audio.to_create_file_dict() for audio in audios]

--- a/podonos/service/evaluation_service.py
+++ b/podonos/service/evaluation_service.py
@@ -187,12 +187,13 @@ class EvaluationService:
         audios: List[Audio],
         timeout: Tuple[float, float] = EvalConfigDefault.API_TIMEOUT,
         context: Optional[Dict[str, Any]] = None,
+        idempotency_keys: Optional[List[str]] = None,
     ):
         try:
             endpoint = f"evaluations/{evaluation_id}/files"
             response = self.api_client.put(
                 endpoint,
-                {"files": [audio.to_create_file_dict() for audio in audios]},
+                {"files": self._build_create_files_body(audios, idempotency_keys)},
                 timeout=timeout,
                 context={
                     "endpoint": endpoint,
@@ -208,6 +209,31 @@ class EvaluationService:
                 f"Failed to create evaluation files: {e}",
                 status_code=getattr(getattr(e, "response", None), "status_code", None),
             )
+
+    @staticmethod
+    def _build_create_files_body(
+        audios: List[Audio], idempotency_keys: Optional[List[str]]
+    ) -> List[Dict[str, Any]]:
+        """Build the create_evaluation_files request body (c3, shape b).
+
+        When idempotency_keys is provided, a per-row `idempotency_key` is zipped into
+        each file dict so the backend can collapse a retried/lost-response POST. The
+        same `data` dict is reused across the HTTP-transport retry in
+        ``api._execute_with_retry`` (the closure captures one body), so the key is
+        byte-stable across retries for free. When None (e.g. callers that do not
+        compute keys), the body is built exactly as before.
+        """
+        if idempotency_keys is None:
+            return [audio.to_create_file_dict() for audio in audios]
+        if len(idempotency_keys) != len(audios):
+            raise ValueError(
+                "idempotency_keys length must equal audios length "
+                f"({len(idempotency_keys)} != {len(audios)})"
+            )
+        return [
+            {**audio.to_create_file_dict(), "idempotency_key": key}
+            for audio, key in zip(audios, idempotency_keys)
+        ]
 
     @validate_args(evaluation_id=Rules.uuid_not_none, remote_object_name=Rules.str_not_none)
     def get_presigned_url(

--- a/tests/core/test_evaluator.py
+++ b/tests/core/test_evaluator.py
@@ -687,9 +687,13 @@ class TestEvaluator(unittest.TestCase):
         self.assertEqual(result.failed_count, 0)
         self.assertEqual(len(result.results), 0)
 
-    def test_retry_failed_uploads_reregisters_metadata_before_verify(self):
-        """Failed verification retry must repair both bytes and metadata."""
+    def test_retry_failed_uploads_reuploads_without_reregistering_metadata(self):
+        """A verify-failure retry repairs the S3 object (re-upload) ONLY; it must not
+        re-POST create_evaluation_files for a file that was already registered. On the
+        default config (no upload ledger) this is the exactly-once guarantee that
+        removes the duplicate-evaluation_file trigger."""
         failed_audio = self._create_test_audio(1)
+        self.assertIsNone(self.evaluator._upload_ledger)  # type: ignore[attr-defined]
         mock_service = Mock()
         self.evaluator._evaluation_service = mock_service  # type: ignore
 
@@ -699,27 +703,13 @@ class TestEvaluator(unittest.TestCase):
 
             self.evaluator._retry_failed_uploads([failed_audio])  # type: ignore
 
+        # re-uploaded (bytes repaired) ...
         mock_manager.add_file_to_queue.assert_called_once_with(
             self.evaluator.get_evaluation_id(), failed_audio
         )
         mock_manager.wait_and_close.assert_called_once()
-        mock_service.create_evaluation_files.assert_called_once_with(
-            self.evaluator.get_evaluation_id(),
-            [failed_audio],
-            timeout=self.evaluator._eval_config.api_timeout,  # type: ignore[attr-defined]
-            context={
-                "batch_index": 0,
-                "batch_size": 1,
-                "batch_start": 0,
-                "total_files": 1,
-            },
-            # This audio belongs to no _ordered_file_groups in this unit test, so the
-            # ordinal is unresolved and the key falls back to a distinct per-file value
-            # (remote_object_name) rather than collapsing onto :0:.
-            idempotency_keys=[
-                f"{self.evaluator.get_evaluation_id()}:r-{failed_audio.remote_object_name}"
-            ],
-        )
+        # ... but NOT re-registered (already registered in the main path)
+        mock_service.create_evaluation_files.assert_not_called()
 
     def test_verify_files_in_batches_large_file_count(self):
         """Test _verify_files_in_batches with 1900 files (customer issue scenario)."""

--- a/tests/core/test_evaluator.py
+++ b/tests/core/test_evaluator.py
@@ -713,6 +713,12 @@ class TestEvaluator(unittest.TestCase):
                 "batch_start": 0,
                 "total_files": 1,
             },
+            # This audio belongs to no _ordered_file_groups in this unit test, so the
+            # ordinal is unresolved and the key falls back to a distinct per-file value
+            # (remote_object_name) rather than collapsing onto :0:.
+            idempotency_keys=[
+                f"{self.evaluator.get_evaluation_id()}:r-{failed_audio.remote_object_name}"
+            ],
         )
 
     def test_verify_files_in_batches_large_file_count(self):

--- a/tests/core/test_large_upload_flow.py
+++ b/tests/core/test_large_upload_flow.py
@@ -1322,6 +1322,74 @@ class TestLargeUploadLedgerFlow(unittest.TestCase):
             ),
         )
 
+    def test_no_ledger_verify_failure_does_not_reregister(self):
+        # resume_upload=False is the DEFAULT, so there is NO upload ledger and the
+        # metadata_acked guard does not exist. A verify failure must still NOT re-POST
+        # create_evaluation_files for a file already registered in the main path —
+        # otherwise the duplicate-evaluation_file incident recurs on the default config.
+        evaluator = self.make_evaluator(resume_upload=False)
+        self.assertIsNone(evaluator._upload_ledger)  # type: ignore[attr-defined]
+        audios = self.fake_audios(3, prefix="no-ledger")
+        content_md5, file_size = calculate_file_md5_base64(TESTDATA_SPEECH_CH1_MP3)
+        for audio in audios:
+            audio.set_integrity_info(content_md5, file_size)
+        evaluator._ordered_file_groups = self.single_stimulus_groups(audios)  # type: ignore[assignment]
+
+        service = evaluator._evaluation_service  # real EvaluationService instance
+        service.process_files = MagicMock(  # type: ignore[method-assign]
+            return_value=SimpleNamespace(processing_count=0)
+        )
+        service.create_evaluation_files = MagicMock()  # type: ignore[method-assign]
+        service.get_presigned_url = MagicMock(  # type: ignore[method-assign]
+            return_value="https://example.com/x"
+        )
+        service.upload_evaluation_file = MagicMock(return_value=MagicMock())  # type: ignore[method-assign]
+
+        failed_once = {"done": False}
+
+        def verify_files(evaluation_id, batch, **kwargs):
+            results = []
+            for audio in batch:
+                if (
+                    audio.remote_object_name == audios[1].remote_object_name
+                    and not failed_once["done"]
+                ):
+                    results.append(
+                        FileVerificationResult(
+                            audio.remote_object_name,
+                            False,
+                            None,
+                            VerificationErrorDetail(
+                                code="SIZE_MISMATCH",
+                                message="bad",
+                                expected="1",
+                                actual="0",
+                            ),
+                        )
+                    )
+                else:
+                    results.append(
+                        FileVerificationResult(audio.remote_object_name, True, "m", None)
+                    )
+            failed = sum(1 for r in results if not r.verified)
+            if failed:
+                failed_once["done"] = True
+            return VerifyFilesResponse(
+                all_verified=(failed == 0),
+                verified_count=len(results) - failed,
+                failed_count=failed,
+                results=results,
+            )
+
+        service.verify_files = MagicMock(side_effect=verify_files)  # type: ignore[method-assign]
+
+        evaluator._process_audio_files_with_verification()
+
+        # registered exactly ONCE (the initial main-path registration); the
+        # verify-failed file is re-uploaded and re-verified but NOT re-registered.
+        service.create_evaluation_files.assert_called_once()
+        service.upload_evaluation_file.assert_called_once()
+
     def test_default_evaluator_does_not_create_state_file(self):
         evaluator = self.make_evaluator(resume_upload=False)
 

--- a/tests/core/test_large_upload_flow.py
+++ b/tests/core/test_large_upload_flow.py
@@ -104,6 +104,11 @@ class TestLargeUploadLedgerFlow(unittest.TestCase):
         assert evaluator._upload_ledger is not None  # type: ignore[attr-defined]
         now = "2026-05-22T00:00:00.000Z"
         content_md5, file_size = calculate_file_md5_base64(TESTDATA_SPEECH_CH1_MP3)
+        # Mirror the production invariant: reaching metadata_registered/verified means
+        # create_evaluation_files returned 2xx, so metadata_acked is set. (mark_metadata_
+        # registered sets status+ack atomically; a registered-but-unacked row cannot
+        # occur in the real flow, so fixtures must not fabricate one.)
+        metadata_acked = 1 if status in ("metadata_registered", "verified") else 0
         for audio in audios:
             audio.set_integrity_info(content_md5, file_size)
         with evaluator._upload_ledger._transaction() as conn:  # type: ignore[union-attr]
@@ -120,9 +125,10 @@ class TestLargeUploadLedgerFlow(unittest.TestCase):
                     manifest_hash,
                     upload_start_at,
                     upload_finish_at,
+                    metadata_acked,
                     created_at,
                     updated_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 [
                     (
@@ -138,10 +144,11 @@ class TestLargeUploadLedgerFlow(unittest.TestCase):
                         build_upload_manifest_hash(
                             audio.to_create_file_dict(), content_md5, file_size
                         ),
-                        now,
-                        now,
-                        now,
-                        now,
+                        now,  # upload_start_at
+                        now,  # upload_finish_at
+                        metadata_acked,
+                        now,  # created_at
+                        now,  # updated_at
                     )
                     for audio in audios
                 ],
@@ -319,11 +326,22 @@ class TestLargeUploadLedgerFlow(unittest.TestCase):
             "verified",
         )
 
-    def test_upload_retry_registers_metadata_before_reverification(self):
+    def test_acked_row_reuploads_and_reverifies_without_reregistration(self):
+        # A row that was actually registered (metadata_acked=True — the production
+        # invariant for metadata_registered) and then fails S3 verify is re-uploaded
+        # and re-verified, but its metadata is NOT re-POSTed. That is the exactly-once
+        # guarantee: a verify failure means the object is bad, not the metadata.
+        # (seed_rows seeds the realistic acked state; a registered-but-unacked row
+        # cannot occur through the real flow.)
         evaluator = self.make_evaluator()
-        audios = self.fake_audios(1, prefix="upload-retry-metadata")
+        audios = self.fake_audios(1, prefix="acked-upload-retry")
         self.seed_rows(evaluator, audios, "metadata_registered")
-        evaluator._ordered_file_groups = [SimpleNamespace(audios=audios)]  # type: ignore[assignment]
+        evaluator._ordered_file_groups = self.single_stimulus_groups(audios)  # type: ignore[assignment]
+        self.assertTrue(
+            evaluator._upload_ledger.get(  # type: ignore[union-attr]
+                evaluator.get_evaluation_id(), audios[0].remote_object_name
+            ).metadata_acked
+        )
 
         service = evaluator._evaluation_service
         service.process_files = MagicMock(  # type: ignore[method-assign]
@@ -346,10 +364,10 @@ class TestLargeUploadLedgerFlow(unittest.TestCase):
                     False,
                     None,
                     VerificationErrorDetail(
-                        code="METADATA_NOT_FOUND",
-                        message="metadata missing after upload",
-                        expected=None,
-                        actual=None,
+                        code="SIZE_MISMATCH",
+                        message="bad object after upload",
+                        expected="1",
+                        actual="0",
                     ),
                 )
             ],
@@ -367,22 +385,22 @@ class TestLargeUploadLedgerFlow(unittest.TestCase):
                 )
             ],
         )
-
-        def verify_after_metadata_retry(*args, **kwargs):
-            if service.verify_files.call_count == 1:  # type: ignore[attr-defined]
-                return failure_response
-            self.assertTrue(service.create_evaluation_files.called)  # type: ignore[attr-defined]
-            return success_response
-
         service.verify_files = MagicMock(  # type: ignore[method-assign]
-            side_effect=verify_after_metadata_retry
+            side_effect=[failure_response, success_response]
         )
 
         evaluator._process_audio_files_with_verification()  # type: ignore[arg-type]
 
+        # re-uploaded (object repaired) and re-verified, but NOT re-registered
         service.upload_evaluation_file.assert_called_once()
-        service.create_evaluation_files.assert_called_once()
+        service.create_evaluation_files.assert_not_called()
         self.assertEqual(service.verify_files.call_count, 2)
+        self.assertEqual(
+            evaluator._upload_ledger.get(  # type: ignore[union-attr]
+                evaluator.get_evaluation_id(), audios[0].remote_object_name
+            ).status,
+            "verified",
+        )
 
     def test_metadata_registration_create_failure_rolls_back_to_uploaded(self):
         evaluator = self.make_evaluator()

--- a/tests/core/test_large_upload_flow.py
+++ b/tests/core/test_large_upload_flow.py
@@ -4,7 +4,7 @@ import unittest
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from types import SimpleNamespace
-from typing import List
+from typing import List, Optional
 from unittest.mock import MagicMock, Mock, patch
 
 from podonos.common.enum import EvalType, QuestionFileType
@@ -16,7 +16,9 @@ from podonos.core.file import Audio, File
 from podonos.core.upload_ledger import (
     build_upload_manifest_hash,
     build_upload_manifest_key,
+    stable_manifest_contract,
 )
+from podonos.service.evaluation_service import EvaluationService
 from podonos.entity.evaluation import EvaluationEntity
 from podonos.entity.verification import (
     FileVerificationResult,
@@ -32,6 +34,12 @@ class FakeAudio:
     path: str
     remote_object_name: str
     is_silent: bool = False
+    # group/order_in_group exist so the c3 idempotency key and the group-ordinal
+    # resolution work against the double. to_create_file_dict() stays minimal (no
+    # "group" key) on purpose: stable_manifest_contract only substitutes when a
+    # "group" key is present, so seeded manifest hashes stay byte-stable.
+    group: Optional[str] = None
+    order_in_group: int = 0
 
     def to_create_file_dict(self):
         return {"uploaded_file_name": self.remote_object_name, "original_name": self.path}
@@ -43,6 +51,16 @@ class FakeAudio:
     def set_upload_at(self, start_at: str, finish_at: str) -> None:
         self.upload_start_at = start_at
         self.upload_finish_at = finish_at
+
+
+@dataclass
+class FakeGroup:
+    """Minimal AudioGroup stand-in carrying its audios (and an optional group_id),
+    used to model the realistic one-group-per-single-stimulus-file layout so the
+    positional group ordinal resolves to distinct values."""
+
+    audios: List["FakeAudio"]
+    group_id: Optional[str] = None
 
 
 class TestLargeUploadLedgerFlow(unittest.TestCase):
@@ -850,6 +868,389 @@ class TestLargeUploadLedgerFlow(unittest.TestCase):
         self.assertIsNotNone(row)
         self.assertEqual(row.status, "queued")
         self.assertEqual(row.local_path, new_path)
+
+    def single_stimulus_groups(self, audios: List[FakeAudio]) -> List[FakeGroup]:
+        """One group per file, mirroring real NMOS/QMOS single-stimulus layout."""
+        return [FakeGroup(audios=[audio]) for audio in audios]
+
+    def _ack_row(self, evaluator: Evaluator, remote: str) -> None:
+        """Drive a seeded metadata_registered row through the real setter so its
+        monotonic metadata_acked flag is set (seed_rows inserts default 0)."""
+        evaluator._upload_ledger.mark_metadata_registered(  # type: ignore[union-attr]
+            evaluator.get_evaluation_id(), remote
+        )
+
+    # ---- US-004 / c2 guard + c1 skip ----
+
+    def test_metadata_acked_row_is_never_reregistered(self):
+        evaluator = self.make_evaluator()
+        audios = self.fake_audios(1, prefix="acked")
+        self.seed_rows(evaluator, audios, "metadata_registered")
+        ledger = evaluator._upload_ledger
+        e = evaluator.get_evaluation_id()
+        r = audios[0].remote_object_name
+        self._ack_row(evaluator, r)  # metadata_acked = 1
+        content_md5, file_size = calculate_file_md5_base64(TESTDATA_SPEECH_CH1_MP3)
+        # churn metadata_registered -> verify_failed -> uploaded; ack must persist
+        ledger.mark_verify_failed(e, r, "VERIFY_FAILED", "bad")  # type: ignore[union-attr]
+        ledger.mark_md5_ready(e, r, content_md5, file_size)  # type: ignore[union-attr]
+        ledger.mark_uploaded(e, r, "t0", "t1")  # type: ignore[union-attr]
+        self.assertEqual(ledger.get(e, r).status, "uploaded")  # type: ignore[union-attr]
+        self.assertTrue(ledger.get(e, r).metadata_acked)  # type: ignore[union-attr]
+
+        service = MagicMock()
+        evaluator._evaluation_service = service  # type: ignore[assignment]
+        evaluator._ordered_file_groups = self.single_stimulus_groups(audios)  # type: ignore[assignment]
+        evaluator._register_metadata_for_audios(audios)  # type: ignore[arg-type]
+
+        service.create_evaluation_files.assert_not_called()
+
+    def test_c2_guard_logs_skip_count(self):
+        evaluator = self.make_evaluator()
+        audios = self.fake_audios(1, prefix="logskip")
+        self.seed_rows(evaluator, audios, "metadata_registered")
+        self._ack_row(evaluator, audios[0].remote_object_name)
+        service = MagicMock()
+        evaluator._evaluation_service = service  # type: ignore[assignment]
+        evaluator._ordered_file_groups = self.single_stimulus_groups(audios)  # type: ignore[assignment]
+
+        with self.assertLogs(level="INFO") as cm:
+            evaluator._register_metadata_for_audios(audios)  # type: ignore[arg-type]
+
+        self.assertTrue(
+            any("Skipped metadata registration for 1" in line for line in cm.output)
+        )
+        service.create_evaluation_files.assert_not_called()
+
+    def test_reverify_after_verify_failure_does_not_reregister(self):
+        evaluator = self.make_evaluator()
+        audios = self.fake_audios(1, prefix="reverify")
+        self.seed_rows(evaluator, audios, "metadata_registered")
+        e = evaluator.get_evaluation_id()
+        r = audios[0].remote_object_name
+        self._ack_row(evaluator, r)  # acked
+        evaluator._upload_ledger.mark_verify_failed(e, r, "VERIFY_FAILED", "bad")  # type: ignore[union-attr]
+
+        service = Mock()
+        evaluator._evaluation_service = service  # type: ignore[assignment]
+        with patch("podonos.core.evaluator.UploadManager") as mock_manager_cls:
+            mock_manager = Mock()
+            mock_manager_cls.return_value = mock_manager
+            evaluator._retry_failed_uploads(audios)  # type: ignore[arg-type]
+
+        # re-uploaded but NOT re-registered (c1 skip + c2 guard)
+        mock_manager.add_file_to_queue.assert_called_once()
+        service.create_evaluation_files.assert_not_called()
+
+    # ---- US-002 / c4 ordinal + manifest stability + merge gate ----
+
+    def test_single_stimulus_groups_get_distinct_ordinals(self):
+        evaluator = self.make_evaluator()
+        audios = self.fake_audios(4, prefix="single")
+        evaluator._ordered_file_groups = self.single_stimulus_groups(audios)  # type: ignore[assignment]
+        e = evaluator.get_evaluation_id()
+
+        keys = [evaluator._idempotency_key(a) for a in audios]  # type: ignore[arg-type]
+        self.assertEqual(keys, [f"{e}:{i}:0" for i in range(4)])
+        self.assertEqual(len(set(keys)), 4)  # no collision -> no under-count
+        ordinals = [evaluator._resolve_group_ordinal(a) for a in audios]  # type: ignore[arg-type]
+        self.assertEqual(ordinals, [0, 1, 2, 3])
+
+    def test_group_ordinal_shared_between_manifest_and_idempotency_key(self):
+        evaluator = self.make_evaluator()
+        audios = self.fake_audios(3, prefix="shared")
+        evaluator._ordered_file_groups = self.single_stimulus_groups(audios)  # type: ignore[assignment]
+        for ordinal, audio in enumerate(audios):
+            key = evaluator._idempotency_key(audio)  # type: ignore[arg-type]
+            self.assertTrue(key.endswith(f":{ordinal}:0"))
+            # the same persisted scalar feeds the manifest contract (G1)
+            self.assertEqual(getattr(audio, "_podonos_group_ordinal"), ordinal)
+
+    def test_queue_time_key_equals_md5_ready_persisted_key(self):
+        evaluator = self.make_evaluator()
+        evaluator._evaluation_service.get_presigned_url = MagicMock(  # type: ignore[method-assign]
+            return_value="https://example.com/presigned-url"
+        )
+        evaluator._evaluation_service.upload_evaluation_file = MagicMock(  # type: ignore[method-assign]
+            return_value=MagicMock()
+        )
+        evaluator.add_file(File(path=TESTDATA_SPEECH_CH1_MP3, model_tag="model"))
+        evaluator._wait_for_uploads()
+
+        ledger = evaluator._upload_ledger
+        rows = ledger.list_by_status(evaluator.get_evaluation_id(), "uploaded")  # type: ignore[union-attr]
+        self.assertEqual(len(rows), 1)
+        audio = evaluator._ordered_file_groups[0].audios[0]
+        # The key the md5-ready site persisted must equal the queue-time key for the
+        # same audio (catches the upload_manager overwrite-no-op regression).
+        self.assertIsNotNone(rows[0].manifest_key)
+        self.assertEqual(rows[0].manifest_key, evaluator._build_current_manifest_key(audio))
+
+    def test_merge_gate_rejects_reordered_acked_row_but_not_same_order(self):
+        evaluator = self.make_evaluator()
+        ledger = evaluator._upload_ledger
+        e = evaluator.get_evaluation_id()
+        content_md5, file_size = calculate_file_md5_base64(TESTDATA_SPEECH_CH1_MP3)
+
+        def make_audio(remote: str, group_id: str) -> Audio:
+            audio = Audio(
+                path=TESTDATA_SPEECH_CH1_MP3,
+                name="speech_ch1.mp3",
+                remote_object_name=remote,
+                script="s",
+                tags=["t"],
+                model_tag="m",
+                is_ref=False,
+                group=group_id,
+                type=QuestionFileType.STIMULUS,
+                order_in_group=0,
+            )
+            audio.set_integrity_info(content_md5, file_size)
+            return audio
+
+        orig = make_audio("slot.wav", "random-group-A")
+        setattr(orig, "_podonos_group_ordinal", 0)
+        hash0 = build_upload_manifest_hash(
+            stable_manifest_contract(orig.to_create_file_dict(), 0),
+            content_md5,
+            file_size,
+        )
+        ledger.upsert_queued_file(e, "slot.wav", orig.path)  # type: ignore[union-attr]
+        ledger.mark_md5_ready(e, "slot.wav", content_md5, file_size, manifest_hash=hash0)  # type: ignore[union-attr]
+        ledger.mark_uploaded(e, "slot.wav", "t0", "t1")  # type: ignore[union-attr]
+        ledger.mark_metadata_registered(e, "slot.wav")  # type: ignore[union-attr] # acked
+        ledger.mark_verified(e, "slot.wav")  # type: ignore[union-attr]
+
+        # same-order resume: regenerated group_id but SAME ordinal -> hash matches ->
+        # no false-positive raise, skips as verified.
+        same = make_audio("slot.wav", "random-group-B")
+        setattr(same, "_podonos_group_ordinal", 0)
+        response = evaluator._verify_files_in_batches(e, [same])  # type: ignore[arg-type]
+        self.assertTrue(response.all_verified)
+
+        # reordered resume: byte-identical file, DIFFERENT ordinal -> hash differs ->
+        # loud ValueError instead of a silent duplicate.
+        reordered = make_audio("slot.wav", "random-group-C")
+        setattr(reordered, "_podonos_group_ordinal", 1)
+        with self.assertRaises(ValueError):
+            evaluator._verify_files_in_batches(e, [reordered])  # type: ignore[arg-type]
+
+    # ---- US-003 / c3 idempotency key ----
+
+    def test_idempotency_keys_aligned_to_batch_to_register(self):
+        # N1: keys are built in lockstep with the post-guard register list, so an
+        # acked (skipped) row does not shift the remaining keys onto wrong files.
+        evaluator = self.make_evaluator()
+        audios = self.fake_audios(3, prefix="align")
+        self.seed_rows(evaluator, audios, "uploaded")
+        # ack the MIDDLE row so it is skipped by the guard
+        self._ack_row(evaluator, audios[1].remote_object_name)
+        service = MagicMock()
+        evaluator._evaluation_service = service  # type: ignore[assignment]
+        evaluator._ordered_file_groups = self.single_stimulus_groups(audios)  # type: ignore[assignment]
+
+        evaluator._register_metadata_for_audios(audios)  # type: ignore[arg-type]
+
+        call = service.create_evaluation_files.call_args
+        registered = call.args[1]
+        keys = call.kwargs["idempotency_keys"]
+        e = evaluator.get_evaluation_id()
+        # row 1 skipped; the surviving rows keep their OWN ordinals (0 and 2)
+        self.assertEqual(
+            [a.remote_object_name for a in registered],
+            [audios[0].remote_object_name, audios[2].remote_object_name],
+        )
+        self.assertEqual(keys, [f"{e}:0:0", f"{e}:2:0"])
+        self.assertEqual(len(keys), len(registered))
+
+    def test_build_create_files_body_zips_keys_and_validates_length(self):
+        audios = self.fake_audios(2, prefix="body")
+        body = EvaluationService._build_create_files_body(audios, ["k0", "k1"])
+        self.assertEqual([f["idempotency_key"] for f in body], ["k0", "k1"])
+        self.assertEqual(body[0]["uploaded_file_name"], audios[0].remote_object_name)
+        # None -> no idempotency_key field (OQ2 backward-compatible path)
+        plain = EvaluationService._build_create_files_body(audios, None)
+        self.assertNotIn("idempotency_key", plain[0])
+        with self.assertRaises(ValueError):
+            EvaluationService._build_create_files_body(audios, ["only-one"])
+
+    def test_e2e_verify_failure_yields_exactly_one_row_per_slot(self):
+        evaluator = self.make_evaluator()
+        audios = self.fake_audios(5, prefix="e2e")
+        self.seed_rows(evaluator, audios, "uploaded")
+        evaluator._ordered_file_groups = self.single_stimulus_groups(audios)  # type: ignore[assignment]
+        e = evaluator.get_evaluation_id()
+
+        registered_keys: List[str] = []
+
+        def create_files(evaluation_id, batch, **kwargs):
+            registered_keys.extend(kwargs.get("idempotency_keys") or [])
+
+        failed_once = {"done": False}
+
+        def verify_files(evaluation_id, batch, **kwargs):
+            results = []
+            for audio in batch:
+                if (
+                    audio.remote_object_name == audios[2].remote_object_name
+                    and not failed_once["done"]
+                ):
+                    results.append(
+                        FileVerificationResult(
+                            audio.remote_object_name,
+                            False,
+                            None,
+                            VerificationErrorDetail(
+                                code="SIZE_MISMATCH",
+                                message="bad",
+                                expected="1",
+                                actual="0",
+                            ),
+                        )
+                    )
+                else:
+                    results.append(
+                        FileVerificationResult(audio.remote_object_name, True, "m", None)
+                    )
+            failed = sum(1 for r in results if not r.verified)
+            if failed:
+                failed_once["done"] = True
+            return VerifyFilesResponse(
+                all_verified=(failed == 0),
+                verified_count=len(results) - failed,
+                failed_count=failed,
+                results=results,
+            )
+
+        service = evaluator._evaluation_service  # real EvaluationService instance
+        service.process_files = MagicMock(return_value=SimpleNamespace(processing_count=0))  # type: ignore[method-assign]
+        service.create_evaluation_files = MagicMock(side_effect=create_files)  # type: ignore[method-assign]
+        service.verify_files = MagicMock(side_effect=verify_files)  # type: ignore[method-assign]
+        service.get_presigned_url = MagicMock(return_value="https://example.com/x")  # type: ignore[method-assign]
+        service.upload_evaluation_file = MagicMock(return_value=MagicMock())  # type: ignore[method-assign]
+
+        evaluator._process_audio_files_with_verification()
+
+        # exactly one registration per slot; the re-verified slot was NOT re-POSTed
+        self.assertEqual(len(registered_keys), 5)
+        self.assertEqual(set(registered_keys), {f"{e}:{i}:0" for i in range(5)})
+        self.assertEqual(registered_keys.count(f"{e}:2:0"), 1)
+        self.assertEqual(
+            evaluator._upload_ledger.counts_by_status(e)["verified"],  # type: ignore[union-attr]
+            5,
+        )
+
+    def test_should_skip_upload_fails_closed_on_acked_row_with_changed_metadata(self):
+        # An already-acked row whose per-file metadata changed must fail loudly, not
+        # silently reset+skip (which would leave stale metadata at the backend).
+        evaluator = self.make_evaluator()
+        ledger = evaluator._upload_ledger
+        e = evaluator.get_evaluation_id()
+        content_md5, file_size = calculate_file_md5_base64(TESTDATA_SPEECH_CH1_MP3)
+
+        def make_audio(script: str) -> Audio:
+            audio = Audio(
+                path=TESTDATA_SPEECH_CH1_MP3,
+                name="speech_ch1.mp3",
+                remote_object_name="slot.wav",
+                script=script,
+                tags=["t"],
+                model_tag="m",
+                is_ref=False,
+                group=None,
+                type=QuestionFileType.STIMULUS,
+                order_in_group=0,
+            )
+            audio.set_integrity_info(content_md5, file_size)
+            return audio
+
+        original = make_audio("original-script")
+        hash0 = build_upload_manifest_hash(
+            stable_manifest_contract(original.to_create_file_dict(), None),
+            content_md5,
+            file_size,
+        )
+        ledger.upsert_queued_file(e, "slot.wav", original.path, file_index=0)  # type: ignore[union-attr]
+        ledger.mark_md5_ready(e, "slot.wav", content_md5, file_size, manifest_hash=hash0)  # type: ignore[union-attr]
+        ledger.mark_uploaded(e, "slot.wav", "t0", "t1")  # type: ignore[union-attr]
+        ledger.mark_metadata_registered(e, "slot.wav")  # acked
+        ledger.mark_verify_failed(e, "slot.wav", "VERIFY_FAILED", "bad")  # type: ignore[union-attr]
+
+        changed = make_audio("CHANGED-script")
+        with self.assertRaises(ValueError):
+            evaluator._should_skip_upload(changed)  # type: ignore[arg-type]
+        # the row was NOT reset for re-upload (would have stranded stale metadata)
+        row = ledger.get(e, "slot.wav")  # type: ignore[union-attr]
+        self.assertEqual(row.status, "verify_failed")
+        self.assertTrue(row.metadata_acked)
+
+    def test_resume_routes_uploaded_acked_row_back_to_verification(self):
+        # c1 crash window: an acked row was re-uploaded (status uploaded) but the
+        # process died before the in-run re-verify. On resume it must be routed to
+        # verification (the c2 guard skips its registration), not finalized unverified.
+        evaluator = self.make_evaluator()
+        audios = self.fake_audios(1, prefix="crashwindow")
+        self.seed_rows(evaluator, audios, "metadata_registered")
+        e = evaluator.get_evaluation_id()
+        r = audios[0].remote_object_name
+        self._ack_row(evaluator, r)
+        content_md5, file_size = calculate_file_md5_base64(TESTDATA_SPEECH_CH1_MP3)
+        evaluator._upload_ledger.mark_verify_failed(e, r, "V", "bad")  # type: ignore[union-attr]
+        evaluator._upload_ledger.mark_md5_ready(e, r, content_md5, file_size)  # type: ignore[union-attr]
+        evaluator._upload_ledger.mark_uploaded(e, r, "t0", "t1")  # type: ignore[union-attr]
+        row = evaluator._upload_ledger.get(e, r)  # type: ignore[union-attr]
+        self.assertEqual(row.status, "uploaded")
+        self.assertTrue(row.metadata_acked)
+
+        needing = evaluator._get_audios_needing_verification(audios)  # type: ignore[arg-type]
+        self.assertEqual([a.remote_object_name for a in needing], [r])
+
+    def test_idempotency_key_unresolved_ordinal_is_distinct_per_file(self):
+        evaluator = self.make_evaluator()
+        a = self.fake_audios(1, prefix="alpha")[0]
+        b = self.fake_audios(1, prefix="beta")[0]
+        # neither audio belongs to a group -> unresolved ordinal -> the keys must
+        # still be distinct (a `:0:` collapse would make the backend merge slots)
+        key_a = evaluator._idempotency_key(a)  # type: ignore[arg-type]
+        key_b = evaluator._idempotency_key(b)  # type: ignore[arg-type]
+        self.assertNotEqual(key_a, key_b)
+        self.assertIn(a.remote_object_name, key_a)
+
+    def test_comparison_group_manifest_stable_across_group_id_regen(self):
+        # Real-Audio coverage of the production ordinal-substitution path for a
+        # non-None (comparison) group: a regenerated random group_id with the same
+        # positional ordinal yields the same manifest key; a different ordinal does not.
+        evaluator = self.make_evaluator()
+        content_md5, file_size = calculate_file_md5_base64(TESTDATA_SPEECH_CH1_MP3)
+
+        def make_audio(remote: str, group_id: str, ordinal: int) -> Audio:
+            audio = Audio(
+                path=TESTDATA_SPEECH_CH1_MP3,
+                name="speech_ch1.mp3",
+                remote_object_name=remote,
+                script="s",
+                tags=["t"],
+                model_tag="m",
+                is_ref=False,
+                group=group_id,
+                type=QuestionFileType.STIMULUS,
+                order_in_group=0,
+            )
+            audio.set_integrity_info(content_md5, file_size)
+            setattr(audio, "_podonos_group_ordinal", ordinal)
+            return audio
+
+        run1 = make_audio("r1.wav", "1700000000000_uuid-A", 0)
+        run2 = make_audio("r2.wav", "1700000001111_uuid-B", 0)
+        self.assertEqual(
+            evaluator._build_current_manifest_key(run1),  # type: ignore[arg-type]
+            evaluator._build_current_manifest_key(run2),  # type: ignore[arg-type]
+        )
+        other_group = make_audio("r3.wav", "1700000000000_uuid-A", 1)
+        self.assertNotEqual(
+            evaluator._build_current_manifest_key(run1),  # type: ignore[arg-type]
+            evaluator._build_current_manifest_key(other_group),  # type: ignore[arg-type]
+        )
 
     def test_default_evaluator_does_not_create_state_file(self):
         evaluator = self.make_evaluator(resume_upload=False)

--- a/tests/core/test_large_upload_flow.py
+++ b/tests/core/test_large_upload_flow.py
@@ -1252,6 +1252,58 @@ class TestLargeUploadLedgerFlow(unittest.TestCase):
             evaluator._build_current_manifest_key(other_group),  # type: ignore[arg-type]
         )
 
+    def test_process_finalization_hash_stable_across_comparison_group_id_regen(self):
+        # The process-files dedupe hash must not flip when a comparison group's
+        # random group_id is regenerated on a cross-process resume (else is_processed
+        # misses and process_files needlessly re-runs). Single-stimulus group=None
+        # must keep the legacy raw hash for backward compatibility.
+        evaluator = self.make_evaluator()
+        content_md5, file_size = calculate_file_md5_base64(TESTDATA_SPEECH_CH1_MP3)
+
+        def mk(group_id, ordinal):
+            audio = Audio(
+                path=TESTDATA_SPEECH_CH1_MP3,
+                name="speech_ch1.mp3",
+                remote_object_name="slot.wav",  # rebound from ledger on resume -> stable
+                script="s",
+                tags=["t"],
+                model_tag="m",
+                is_ref=False,
+                group=group_id,
+                type=QuestionFileType.STIMULUS,
+                order_in_group=0,
+            )
+            audio.set_integrity_info(content_md5, file_size)
+            setattr(audio, "_podonos_group_ordinal", ordinal)
+            return audio
+
+        def proc_hash(audio):
+            return evaluator._finalization_hash(  # type: ignore[attr-defined]
+                {
+                    "evaluation_id": evaluator.get_evaluation_id(),
+                    "files": [evaluator._stable_manifest_contract(audio)],  # type: ignore[attr-defined]
+                }
+            )
+
+        # comparison group: regenerated random group_id, same ordinal -> same hash
+        self.assertEqual(proc_hash(mk("rand-A", 0)), proc_hash(mk("rand-B", 0)))
+        # the fix is load-bearing: raw to_create_file_dict would differ
+        raw_a = evaluator._finalization_hash(  # type: ignore[attr-defined]
+            {"evaluation_id": evaluator.get_evaluation_id(), "files": [mk("rand-A", 0).to_create_file_dict()]}
+        )
+        raw_b = evaluator._finalization_hash(  # type: ignore[attr-defined]
+            {"evaluation_id": evaluator.get_evaluation_id(), "files": [mk("rand-B", 0).to_create_file_dict()]}
+        )
+        self.assertNotEqual(raw_a, raw_b)
+        # single-stimulus (group=None) keeps the legacy raw hash (backward compatible)
+        single = mk(None, 0)
+        self.assertEqual(
+            proc_hash(single),
+            evaluator._finalization_hash(  # type: ignore[attr-defined]
+                {"evaluation_id": evaluator.get_evaluation_id(), "files": [single.to_create_file_dict()]}
+            ),
+        )
+
     def test_default_evaluator_does_not_create_state_file(self):
         evaluator = self.make_evaluator(resume_upload=False)
 

--- a/tests/core/test_upload_ledger.py
+++ b/tests/core/test_upload_ledger.py
@@ -9,6 +9,7 @@ from podonos.core.upload_ledger import (
     InvalidUploadLedgerTransition,
     UploadLedger,
     build_upload_manifest_key,
+    stable_manifest_contract,
 )
 
 
@@ -417,6 +418,198 @@ class TestUploadLedger(unittest.TestCase):
         _, path = self.make_ledger()
 
         self.assertEqual(os.stat(path).st_mode & 0o777, 0o600)
+
+    def test_mark_metadata_registered_sets_metadata_acked(self):
+        ledger, _ = self.make_ledger()
+        e, r = "eval-1", "remote-1.wav"
+        ledger.upsert_queued_file(e, r, "/tmp/local.wav")
+        ledger.mark_md5_ready(e, r, "abc==", 123)
+        ledger.mark_uploaded(e, r, "2026-05-22T00:00:00.000Z", "2026-05-22T00:00:01.000Z")
+        self.assertFalse(ledger.get(e, r).metadata_acked)  # type: ignore[union-attr]
+        registered = ledger.mark_metadata_registered(e, r)
+        self.assertTrue(registered.metadata_acked)
+
+    def test_metadata_acked_is_monotonic_across_status_churn(self):
+        ledger, _ = self.make_ledger()
+        e, r = "eval-1", "remote-1.wav"
+        ledger.upsert_queued_file(e, r, "/tmp/local.wav")
+        ledger.mark_md5_ready(e, r, "abc==", 123)
+        ledger.mark_uploaded(e, r, "2026-05-22T00:00:00.000Z", "2026-05-22T00:00:01.000Z")
+        ledger.mark_metadata_registered(e, r)
+        # metadata_registered -> verify_failed -> md5_ready -> uploaded must keep ack
+        ledger.mark_verify_failed(e, r, "VERIFY_FAILED", "bad")
+        self.assertTrue(ledger.get(e, r).metadata_acked)  # type: ignore[union-attr]
+        ledger.mark_md5_ready(e, r, "def==", 456)
+        ledger.mark_uploaded(e, r, "2026-05-22T00:01:00.000Z", "2026-05-22T00:01:01.000Z")
+        self.assertTrue(ledger.get(e, r).metadata_acked)  # type: ignore[union-attr]
+        # reset_for_reupload must not clear the monotonic ack either
+        ledger.reset_for_reupload(e, r, "/tmp/local.wav")
+        self.assertTrue(ledger.get(e, r).metadata_acked)  # type: ignore[union-attr]
+
+    def test_migration_backfills_metadata_acked_for_registered_and_verified(self):
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        path = os.path.join(temp_dir.name, "prefix-state.sqlite")
+        conn = sqlite3.connect(path)
+        try:
+            conn.executescript(
+                """
+                CREATE TABLE upload_ledger (
+                    evaluation_id TEXT NOT NULL,
+                    remote_object_name TEXT NOT NULL,
+                    local_path TEXT NOT NULL,
+                    file_index INTEGER,
+                    status TEXT NOT NULL,
+                    content_md5 TEXT,
+                    file_size INTEGER,
+                    manifest_key TEXT,
+                    manifest_hash TEXT,
+                    upload_start_at TEXT,
+                    upload_finish_at TEXT,
+                    error_type TEXT,
+                    error_message TEXT,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    PRIMARY KEY (evaluation_id, remote_object_name),
+                    CHECK (status IN (
+                        'queued','md5_ready','uploaded','metadata_registering',
+                        'metadata_registered','verified','upload_failed','verify_failed'
+                    ))
+                );
+                INSERT INTO upload_ledger
+                    (evaluation_id, remote_object_name, local_path, status, created_at, updated_at)
+                VALUES
+                    ('eval-1','r-queued.wav','/tmp/q.wav','queued','now','now'),
+                    ('eval-1','r-uploaded.wav','/tmp/u.wav','uploaded','now','now'),
+                    ('eval-1','r-registering.wav','/tmp/rg.wav','metadata_registering','now','now'),
+                    ('eval-1','r-registered.wav','/tmp/rd.wav','metadata_registered','now','now'),
+                    ('eval-1','r-verified.wav','/tmp/v.wav','verified','now','now');
+                """
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        ledger = UploadLedger(path)
+
+        def acked(remote: str) -> bool:
+            return ledger.get("eval-1", remote).metadata_acked  # type: ignore[union-attr]
+
+        # provably-already-POSTed rows are backfilled
+        self.assertTrue(acked("r-registered.wav"))
+        self.assertTrue(acked("r-verified.wav"))
+        # everything else (including the unconfirmed metadata_registering) stays false
+        self.assertFalse(acked("r-queued.wav"))
+        self.assertFalse(acked("r-uploaded.wav"))
+        self.assertFalse(acked("r-registering.wav"))
+
+        # backfill is idempotent: re-opening does not change anything
+        reopened = UploadLedger(path)
+        self.assertTrue(reopened.get("eval-1", "r-verified.wav").metadata_acked)  # type: ignore[union-attr]
+        self.assertFalse(reopened.get("eval-1", "r-registering.wav").metadata_acked)  # type: ignore[union-attr]
+
+    def test_migration_backfills_metadata_acked_through_table_rebuild(self):
+        # Exercises the COMBINED path: an ancient table with NO metadata_registering
+        # CHECK (forces _migrate_status_check_if_needed to rebuild) AND no
+        # metadata_acked column. The rebuild must project metadata_acked via
+        # CASE EXISTS(...), then the backfill must set registered/verified -> 1.
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        path = os.path.join(temp_dir.name, "ancient-state.sqlite")
+        conn = sqlite3.connect(path)
+        try:
+            conn.executescript(
+                """
+                CREATE TABLE upload_ledger (
+                    evaluation_id TEXT NOT NULL,
+                    remote_object_name TEXT NOT NULL,
+                    local_path TEXT NOT NULL,
+                    file_index INTEGER,
+                    status TEXT NOT NULL,
+                    content_md5 TEXT,
+                    file_size INTEGER,
+                    upload_start_at TEXT,
+                    upload_finish_at TEXT,
+                    error_type TEXT,
+                    error_message TEXT,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    PRIMARY KEY (evaluation_id, remote_object_name)
+                );
+                INSERT INTO upload_ledger
+                    (evaluation_id, remote_object_name, local_path, status, created_at, updated_at)
+                VALUES
+                    ('eval-1','r-registered.wav','/tmp/rd.wav','metadata_registered','now','now'),
+                    ('eval-1','r-verified.wav','/tmp/v.wav','verified','now','now'),
+                    ('eval-1','r-queued.wav','/tmp/q.wav','queued','now','now');
+                """
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        ledger = UploadLedger(path)
+        # rebuild happened (the new CHECK now permits metadata_registering)
+        ledger.upsert_queued_file("eval-1", "r-new.wav", "/tmp/n.wav")
+        ledger.mark_md5_ready("eval-1", "r-new.wav", "abc==", 1)
+        ledger.mark_uploaded("eval-1", "r-new.wav", "t0", "t1")
+        self.assertEqual(
+            ledger.mark_metadata_registering("eval-1", "r-new.wav").status,
+            "metadata_registering",
+        )
+        # backfill survived the rebuild
+        self.assertTrue(ledger.get("eval-1", "r-registered.wav").metadata_acked)  # type: ignore[union-attr]
+        self.assertTrue(ledger.get("eval-1", "r-verified.wav").metadata_acked)  # type: ignore[union-attr]
+        self.assertFalse(ledger.get("eval-1", "r-queued.wav").metadata_acked)  # type: ignore[union-attr]
+
+    def test_stable_manifest_contract_is_stable_across_group_id_regen(self):
+        run1 = {
+            "uploaded_file_name": "a.wav",
+            "model_tag": "m",
+            "group": "1700000000000_uuid-A",
+            "order_in_group": 0,
+        }
+        run2 = {
+            "uploaded_file_name": "b.wav",
+            "model_tag": "m",
+            "group": "1700000001111_uuid-B",
+            "order_in_group": 0,
+        }
+        key1 = build_upload_manifest_key(stable_manifest_contract(run1, 0), "md5", 10)
+        key2 = build_upload_manifest_key(stable_manifest_contract(run2, 0), "md5", 10)
+        # different random group_id, same positional ordinal -> same identity
+        self.assertEqual(key1, key2)
+        # different ordinal (a distinct group) -> distinct identity (#318 preserved)
+        key_other = build_upload_manifest_key(
+            stable_manifest_contract(run1, 1), "md5", 10
+        )
+        self.assertNotEqual(key1, key_other)
+        # no ordinal -> raw identity kept unchanged (isolated callers / no group key)
+        raw = build_upload_manifest_key(run1, "md5", 10)
+        self.assertEqual(
+            build_upload_manifest_key(stable_manifest_contract(run1, None), "md5", 10),
+            raw,
+        )
+        no_group = {"uploaded_file_name": "a.wav", "model_tag": "m"}
+        self.assertEqual(stable_manifest_contract(no_group, 3), no_group)
+
+    def test_stable_manifest_contract_preserves_none_group_for_backward_compat(self):
+        # Single-stimulus rows carry group=None, which is already a stable constant.
+        # Substituting it to an ordinal would change the manifest identity and break
+        # resume of ledgers written by prior SDK versions (stored with group=None).
+        single = {
+            "uploaded_file_name": "a.wav",
+            "model_tag": "m",
+            "group": None,
+            "order_in_group": 0,
+        }
+        # even with a resolved ordinal, a None group is left untouched
+        self.assertIsNone(stable_manifest_contract(single, 0)["group"])
+        legacy_key = build_upload_manifest_key(single, "md5", 10)
+        self.assertEqual(
+            build_upload_manifest_key(stable_manifest_contract(single, 0), "md5", 10),
+            legacy_key,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/integration/verify_failure_reupload_e2e.py
+++ b/tests/integration/verify_failure_reupload_e2e.py
@@ -1,0 +1,532 @@
+#!/usr/bin/env python
+"""Opt-in dev-server E2E: reproduce the verify-failure -> re-upload path and
+prove the exactly-once-registration fix.
+
+Background
+----------
+The production incident was: a file that had already been registered
+(``create_evaluation_files`` / ``PUT evaluations/{id}/files``) failed S3
+verification, and the SDK then *re-registered* its metadata on the retry. That
+second POST inserted a duplicate ``evaluation_file`` row into the group.
+
+The fix decouples verify-retry from registration: a verify failure means the S3
+object was bad, not the metadata, so the SDK must re-upload + re-verify ONLY and
+never re-POST ``create_evaluation_files`` for an already-registered file. This
+must hold for BOTH configurations:
+  * ``resume_upload=False`` (the DEFAULT, and the config the incident ran on) --
+    no ledger, the verify-retry path early-returns without re-registering.
+  * ``resume_upload=True``  (opt-in ledger) -- the already-acked row is skipped.
+
+How this harness reproduces it (deterministic, no proxy/corruption needed)
+--------------------------------------------------------------------------
+We do a real upload to the dev server, then force exactly one verify failure in
+process so the SDK takes its real retry path against the real backend:
+
+  * Wrap ``EvaluationService.verify_files``: on the FIRST verify call, flip
+    exactly one genuinely-verified file to ``verified=False`` (a synthetic
+    forced failure) and fix up the response counts. Every later call passes the
+    real backend result through, so when the SDK re-uploads that file it
+    verifies for real on the retry.
+  * Spy on ``EvaluationService.create_evaluation_files``: record the remote
+    object names registered on every call.
+
+After ``close()`` we assert:
+  * the run completed (``{"status": "ok"}``)            -> the retry path worked
+    end to end against the real backend;
+  * the forced failure actually fired                   -> not a vacuous pass;
+  * ``verify_files`` was called >= 2 times              -> the retry really ran;
+  * the failed file was re-verified=True on a later pass -> it was genuinely
+    recovered, not silently dropped;
+  * every remote_object_name was registered <= once     -> NO re-registration
+    (the failed file in particular appears exactly once). This is precisely the
+    invariant the bug violated, so a regression would re-register the failed
+    file and this assertion would catch it. The create-spy is the *true* witness
+    of "no duplicate backend row", because the duplicate was caused precisely by
+    the second ``create_evaluation_files`` POST.
+  * (ledger only) the ledger ends with one row per file, all ``verified``. This
+    guards SDK-local ledger-row integrity; it is NOT an independent witness of
+    backend duplication (a re-POST reuses the same remote_object_name key and
+    would not create a second ledger row), so the create-spy above remains the
+    decisive check.
+
+Group shapes
+------------
+The incident symptom was a duplicate file *within a group*, so the harness
+exercises single- and multi-file groups (``--shape``):
+  * single -> NMOS  -- 1 file/group  (add_file)
+  * double -> CMOS  -- 1 stimulus + 1 reference per group (add_files)
+  * triple -> CSMOS -- 2 stimuli + 1 reference per group  (add_files)
+The synthetic failure is injected on exactly one file of one group; the assertion
+"that file's remote_object_name is registered exactly once" is the same per-file
+invariant in every shape -- a re-registration would add an extra row to its
+group, which is precisely the incident.
+
+Scope: a single initial registration/verify batch. ``--items`` x group_size is
+capped at 20 files/eval, well under the SDK's 500-file ``create_evaluation_files``
+batch size and the pinned per-run verify batch. The >500-file / multi-initial-
+batch dimension is out of scope here and is covered by the unit suite.
+
+These hit the real dev backend and perform real presigned-url uploads, so the
+script is a no-op unless explicitly enabled. By default it runs every shape x
+both configs (6 small evaluations); scope it down with --shape / --config.
+
+Run
+---
+    # all shapes (single/double/triple) x both configs
+    PODONOS_E2E=1 PODONOS_API_KEY=<KEY> \
+      python tests/integration/verify_failure_reupload_e2e.py
+
+    # just the triple (CSMOS) shape, default config only, on dev
+    PODONOS_E2E=1 PODONOS_API_KEY=<KEY> \
+      PODONOS_E2E_BASE_URL=https://dev.podonosapi.com \
+      python tests/integration/verify_failure_reupload_e2e.py \
+        --shape triple --config no-ledger --items 2
+
+Env / flags
+-----------
+    PODONOS_E2E=1                  Required opt-in guard.
+    PODONOS_API_KEY=<KEY>          Required API key.
+    PODONOS_E2E_BASE_URL=<URL>     Defaults to https://dev.podonosapi.com. Must be
+                                   a Podonos-owned https host unless
+                                   PODONOS_E2E_ALLOW_UNTRUSTED_BASE_URL=1.
+    PODONOS_E2E_AUDIO_PATH=<PATH>  Optional audio fixture override.
+    --shape {single,double,triple,all}  Group shape(s). Default all.
+    --config {both,no-ledger,ledger}    Which config(s) to exercise. Default both.
+    --items N                           Groups per evaluation (items x group_size
+                                        <= 20). Default 2.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import tempfile
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, List, Optional, Tuple
+from urllib.parse import urlparse
+
+# Make the in-tree package importable when run directly as a script
+# (python tests/integration/verify_failure_reupload_e2e.py), not only under an
+# editable install or `python -m`. Front-insert so the local working copy (the
+# code under test, with the fix) wins over any installed podonos.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import podonos  # noqa: E402
+from podonos import File  # noqa: E402
+from podonos.core.upload_ledger import UploadLedger  # noqa: E402
+from podonos.entity.verification import (  # noqa: E402
+    VerificationErrorDetail,
+    VerifyFilesResponse,
+)
+
+_DEV_BASE_URL = "https://dev.podonosapi.com"
+_TRUTHY = {"1", "true", "yes", "y", "on"}
+_MAX_FILES_PER_EVAL = 20
+_DEFAULT_AUDIO_PATH = Path(__file__).resolve().parents[1] / "core" / "speech_ch1.mp3"
+
+
+@dataclass(frozen=True)
+class _Shape:
+    """A group shape: how many files the SDK uploads per evaluation item."""
+
+    name: str
+    eval_type: str
+    group_size: int
+
+
+# single -> NMOS:  one audio per group           (add_file)
+# double -> CMOS:  one stimulus + one reference   (add_files)
+# triple -> CSMOS: two stimuli + one reference    (add_files)
+_SHAPES = {
+    "single": _Shape("single", "NMOS", 1),
+    "double": _Shape("double", "CMOS", 2),
+    "triple": _Shape("triple", "CSMOS", 3),
+}
+
+
+def _truthy_env(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in _TRUTHY
+
+
+def _validate_base_url(base_url: str) -> str:
+    if _truthy_env("PODONOS_E2E_ALLOW_UNTRUSTED_BASE_URL"):
+        return base_url
+    parsed = urlparse(base_url)
+    host = (parsed.hostname or "").lower()
+    if parsed.scheme != "https":
+        raise SystemExit("PODONOS_E2E_BASE_URL must use https.")
+    if not (
+        host == "podonosapi.com"
+        or host.endswith(".podonosapi.com")
+        or host == "podonos.com"
+        or host.endswith(".podonos.com")
+    ):
+        raise SystemExit(
+            "PODONOS_E2E_BASE_URL must be a Podonos-owned host. Set "
+            "PODONOS_E2E_ALLOW_UNTRUSTED_BASE_URL=1 only for intentional local testing."
+        )
+    return base_url
+
+
+def _unique_name(prefix: str) -> str:
+    stamp = time.strftime("%Y%m%d-%H%M%S")
+    return f"{prefix}-{stamp}-{uuid.uuid4().hex[:8]}"
+
+
+class _EnvironmentNotClean(RuntimeError):
+    """The real backend state made a trustworthy injection impossible.
+
+    Raised when the initial verify pass is not the single, fully-clean batch the
+    harness needs (e.g. the backend genuinely failed a file, fragmented the
+    initial verify, or did not round-trip the uploaded file name). This is an
+    inconclusive run, not a fix failure -- re-run rather than trusting a verdict
+    built on top of real backend noise.
+    """
+
+
+class _ForcedVerifyFailure:
+    """One-shot, in-process verify-failure injector + registration spy.
+
+    Wraps the live ``EvaluationService`` bound methods on a single evaluator so
+    the SDK takes its real retry path against the real backend, while we observe
+    exactly how many times each file's metadata is registered.
+    """
+
+    def __init__(self, expected_file_count: int) -> None:
+        self.expected_file_count = expected_file_count
+        self.verify_calls = 0
+        self.injected = False
+        self.reverified = False
+        self.target: Optional[str] = None
+        # One list of remote_object_names per create_evaluation_files call.
+        self.register_calls: List[List[str]] = []
+
+    def install(self, service) -> None:
+        original_verify: Callable[..., VerifyFilesResponse] = service.verify_files
+        original_create: Callable[..., object] = service.create_evaluation_files
+
+        def verify_wrapper(evaluation_id, audios, *args, **kwargs):
+            response = original_verify(evaluation_id, audios, *args, **kwargs)
+            self.verify_calls += 1
+            if not self.injected:
+                # Inject strictly on the first verify call. We pin
+                # verify_batch_size == file_count so this call IS the whole
+                # initial pass; guard that invariant and that the backend gave a
+                # clean result, otherwise real backend noise would be folded into
+                # the synthetic failure and corrupt the verdict.
+                if len(audios) != self.expected_file_count:
+                    raise _EnvironmentNotClean(
+                        f"initial verify fragmented into a {len(audios)}-file "
+                        f"batch; expected a single {self.expected_file_count}-file "
+                        "batch."
+                    )
+                if not (response.all_verified and response.failed_count == 0):
+                    raise _EnvironmentNotClean(
+                        f"initial verify pass already had {response.failed_count} "
+                        "real backend failure(s); cannot inject a clean synthetic "
+                        "failure on top of it."
+                    )
+                self._flip_one_verified(response)
+                if self.target_registration_count() < 1:
+                    raise _EnvironmentNotClean(
+                        f"backend did not round-trip uploaded file name "
+                        f"{self.target!r}; it was never registered, so the "
+                        "exactly-once check would be meaningless."
+                    )
+            else:
+                # A later (retry) pass: positive witness that the re-uploaded
+                # file actually came back verified, so 'registered exactly once'
+                # cannot pass vacuously by silently dropping the failed file.
+                for result in response.results:
+                    if result.uploaded_file_name == self.target and result.verified:
+                        self.reverified = True
+            return response
+
+        def create_wrapper(evaluation_id, audios, *args, **kwargs):
+            self.register_calls.append([a.remote_object_name for a in audios])
+            return original_create(evaluation_id, audios, *args, **kwargs)
+
+        service.verify_files = verify_wrapper
+        service.create_evaluation_files = create_wrapper
+
+    def _flip_one_verified(self, response: VerifyFilesResponse) -> None:
+        for result in response.results:
+            if result.verified:
+                result.verified = False
+                result.error = VerificationErrorDetail(
+                    code="E2E_FORCED_FAILURE",
+                    message="Synthetic verify failure injected by the E2E harness.",
+                )
+                response.verified_count = max(0, response.verified_count - 1)
+                response.failed_count += 1
+                response.all_verified = False
+                self.injected = True
+                self.target = result.uploaded_file_name
+                return
+
+    # -- assertions -----------------------------------------------------------
+
+    def duplicate_registrations(self) -> List[Tuple[str, int]]:
+        counts: dict[str, int] = {}
+        for names in self.register_calls:
+            for name in names:
+                counts[name] = counts.get(name, 0) + 1
+        return [(name, n) for name, n in counts.items() if n > 1]
+
+    def target_registration_count(self) -> int:
+        return sum(names.count(self.target) for names in self.register_calls)
+
+
+def _add_groups(etor, audio_path: Path, shape: _Shape, items: int) -> None:
+    """Queue ``items`` groups of ``shape.group_size`` files each.
+
+    A multi-file group (double/triple) is exactly where "duplicate file in the
+    group" -- the original incident symptom -- is meaningful: a re-registration
+    of one member would add an extra row to that group.
+    """
+    path = str(audio_path)
+    script = "verify-failure re-upload e2e"
+    for i in range(items):
+        if shape.group_size == 1:  # NMOS
+            etor.add_file(
+                File(path=path, model_tag=f"vf_{shape.name}_{i}", script=script)
+            )
+        elif shape.group_size == 2:  # CMOS: one stimulus + one reference
+            etor.add_files(
+                file0=File(
+                    path=path, model_tag=f"vf_{shape.name}_stim_{i}", script=script
+                ),
+                file1=File(
+                    path=path,
+                    model_tag=f"vf_{shape.name}_ref",
+                    script=script,
+                    is_ref=True,
+                ),
+            )
+        else:  # CSMOS: two distinct-tag stimuli + one reference (ref is 3rd)
+            # Double-stimuli types pin a canonical pair of stimulus model_tags
+            # across all groups, so a/b must be constant (not per-item).
+            etor.add_files(
+                file0=File(
+                    path=path, model_tag=f"vf_{shape.name}_a", script=script
+                ),
+                file1=File(
+                    path=path, model_tag=f"vf_{shape.name}_b", script=script
+                ),
+                file2=File(
+                    path=path,
+                    model_tag=f"vf_{shape.name}_ref",
+                    script=script,
+                    is_ref=True,
+                ),
+            )
+
+
+def _run_config(
+    *,
+    api_key: str,
+    base_url: str,
+    audio_path: Path,
+    shape: _Shape,
+    items: int,
+    use_ledger: bool,
+) -> Optional[bool]:
+    """Return True/False for pass/fail, or None if the run was inconclusive
+    (the real backend state made a trustworthy injection impossible)."""
+    total_files = items * shape.group_size
+    label = "ledger (resume_upload=True)" if use_ledger else "no-ledger (DEFAULT)"
+    print(
+        f"\n=== shape={shape.name} ({shape.eval_type}, {shape.group_size}/group) "
+        f"| config: {label} | items={items} files={total_files} ==="
+    )
+
+    client = podonos.init(api_key=api_key, api_url=base_url)
+
+    state_path: Optional[str] = None
+    extra_kwargs = {}
+    if use_ledger:
+        state_dir = tempfile.mkdtemp(prefix="podonos-e2e-verify-fail-")
+        state_path = str(Path(state_dir) / "upload-state.sqlite")
+        extra_kwargs = {"resume_upload": True, "upload_state_path": state_path}
+
+    etor = client.create_evaluator(
+        name=_unique_name(f"sdk-verify-fail-{shape.name}"),
+        desc="E2E: verify-failure re-upload must not re-register metadata",
+        type=shape.eval_type,
+        lan="en-us",
+        num_eval=1,
+        due_hours=12,
+        auto_start=False,
+        max_upload_workers=2,
+        # Force a single initial verify batch so the first verify_files call is
+        # the whole initial pass; the injector targets one file from it.
+        verify_batch_size=max(1, min(1000, total_files)),
+        **extra_kwargs,
+    )
+
+    evaluation_id = etor.get_evaluation_id()
+    injector = _ForcedVerifyFailure(expected_file_count=total_files)
+    injector.install(etor._evaluation_service)  # type: ignore[attr-defined]
+
+    _add_groups(etor, audio_path, shape, items)
+
+    try:
+        result = etor.close()
+    except _EnvironmentNotClean as exc:
+        print(f"  [INCONCLUSIVE] {exc}")
+        print(f"  evaluation_id={evaluation_id}")
+        return None
+
+    ok = True
+
+    def check(name: str, passed: bool, detail: str = "") -> None:
+        nonlocal ok
+        ok = ok and passed
+        mark = "PASS" if passed else "FAIL"
+        print(f"  [{mark}] {name}{(' -> ' + detail) if detail else ''}")
+
+    check("run completed", result == {"status": "ok"}, f"result={result}")
+    check(
+        "forced verify failure fired",
+        injector.injected,
+        f"target={injector.target}",
+    )
+    check(
+        "retry path ran (verify_files called >= 2)",
+        injector.verify_calls >= 2,
+        f"verify_calls={injector.verify_calls}",
+    )
+    check(
+        "failed file re-verified on retry",
+        injector.reverified,
+        f"reverified={injector.reverified}",
+    )
+    dupes = injector.duplicate_registrations()
+    check(
+        "no file registered more than once",
+        not dupes,
+        f"duplicates={dupes}" if dupes else "all <= 1",
+    )
+    check(
+        "failed file registered exactly once",
+        injector.injected and injector.target_registration_count() == 1,
+        f"target_count={injector.target_registration_count()}",
+    )
+
+    if use_ledger and state_path:
+        ledger = UploadLedger(state_path)
+        counts = ledger.counts_by_status(evaluation_id)
+        check(
+            "ledger: every file verified, one row each",
+            counts.get("verified", 0) == total_files
+            and sum(counts.values()) == total_files,
+            f"counts={counts}",
+        )
+
+    print(f"  evaluation_id={evaluation_id}")
+    return ok
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--shape",
+        choices=["single", "double", "triple", "all"],
+        default="all",
+        help=(
+            "Group shape(s): single=NMOS (1/group), double=CMOS (2/group), "
+            "triple=CSMOS (3/group), all=every shape. Default: all."
+        ),
+    )
+    parser.add_argument(
+        "--config",
+        choices=["both", "no-ledger", "ledger"],
+        default="both",
+        help="Which configuration(s) to exercise. Default: both.",
+    )
+    parser.add_argument(
+        "--items",
+        type=int,
+        default=2,
+        help="Groups (items) per evaluation. Default: 2.",
+    )
+    args = parser.parse_args()
+
+    if not (_truthy_env("PODONOS_E2E") or _truthy_env("PODONOS_DEV_E2E")):
+        print(
+            "Skipped: set PODONOS_E2E=1 and PODONOS_API_KEY to run this real "
+            "dev-server E2E.\nExample:\n"
+            "  PODONOS_E2E=1 PODONOS_API_KEY=<KEY> "
+            "python tests/integration/verify_failure_reupload_e2e.py",
+            file=sys.stderr,
+        )
+        return 2
+
+    api_key = os.getenv("PODONOS_API_KEY")
+    if not api_key:
+        print("Skipped: set PODONOS_API_KEY to run this E2E.", file=sys.stderr)
+        return 2
+
+    shapes = (
+        list(_SHAPES.values()) if args.shape == "all" else [_SHAPES[args.shape]]
+    )
+    if args.items < 1:
+        print("--items must be >= 1.", file=sys.stderr)
+        return 2
+    for shape in shapes:
+        if args.items * shape.group_size > _MAX_FILES_PER_EVAL:
+            print(
+                f"--items={args.items} x {shape.group_size} files/group exceeds the "
+                f"{_MAX_FILES_PER_EVAL}-file smoke cap for shape '{shape.name}'.",
+                file=sys.stderr,
+            )
+            return 2
+
+    base_url = _validate_base_url(
+        os.getenv("PODONOS_E2E_BASE_URL")
+        or os.getenv("PODONOS_DEV_BASE_URL")
+        or _DEV_BASE_URL
+    )
+    audio_path = Path(os.getenv("PODONOS_E2E_AUDIO_PATH", str(_DEFAULT_AUDIO_PATH)))
+    if not audio_path.is_file():
+        print(f"Audio fixture does not exist: {audio_path}", file=sys.stderr)
+        return 2
+
+    configs: List[bool] = []
+    if args.config in ("both", "no-ledger"):
+        configs.append(False)
+    if args.config in ("both", "ledger"):
+        configs.append(True)
+
+    print(f"dev-server verify-failure re-upload E2E | base_url={base_url}")
+    results: List[Optional[bool]] = []
+    for shape in shapes:
+        for use_ledger in configs:
+            results.append(
+                _run_config(
+                    api_key=api_key,
+                    base_url=base_url,
+                    audio_path=audio_path,
+                    shape=shape,
+                    items=args.items,
+                    use_ledger=use_ledger,
+                )
+            )
+
+    if any(r is None for r in results):
+        print(
+            "\n=== RESULT: INCONCLUSIVE (backend state not clean for injection; "
+            "re-run) ==="
+        )
+        return 2
+    all_ok = all(results)
+    print("\n=== RESULT:", "PASS ===" if all_ok else "FAIL ===")
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Context
File metadata registration (`create_evaluation_files`) is non-idempotent at the call layer: the backend inserts an `evaluation_file` row per logical slot. The SDK could call it more than once for the same logical file, and combined with edge cases this produced duplicate rows (a comparison group ending up with more `evaluation_file` rows than its `batch_size`).

## Problem
When a file failed S3 verification *after* its metadata had already been registered, the verify-failure retry path re-uploaded it and registered it again, inserting a duplicate row. This held in **both** SDK configurations:
- **Default (`resume_upload=False`, no upload ledger) — the out-of-the-box config, since resume is opt-in:** the verify-retry path had no "already registered" guard at all, so it re-registered every re-uploaded file unconditionally.
- **Opt-in ledger (`resume_upload=True`):** the ledger state machine lost the "already registered" fact — a registered row that failed verify reverted to `uploaded` and re-qualified for registration.

Two related latent paths could also duplicate: an HTTP-transport retry / lost-response-after-commit on `create_evaluation_files`, and a cross-process resume where the manifest identity embedded a random per-run group id and minted a fresh identity that escaped dedup.

## Solution
Make registration exactly-once at the SDK so the trigger is removed regardless of the backend backstop:

- **Decoupled verify-retry from registration** (`evaluator.py`), in **both** configurations: a verify failure means the S3 object was bad, not the metadata, so the retry re-uploads + re-verifies only and never re-POSTs `create_evaluation_files` for an already-registered file.
  - **Default (no ledger):** `_retry_failed_uploads` early-returns after re-upload. Every file reaching verify-retry was already registered in the main path, so none may be re-registered. This closes the duplicate trigger on the default config too.
  - **Opt-in ledger:** skips already-acked re-uploads via the `metadata_acked` guard; `_get_audios_needing_verification` routes re-uploaded acked rows back to verification on resume so a file never finalizes unverified.
- **Durable `metadata_acked` ledger flag** (`upload_ledger.py`): a monotonic column set atomically in `mark_metadata_registered`, never reset by later status churn. The guard in `_register_metadata_for_audios` (the sole `create_evaluation_files` caller) skips any acked row regardless of status.
- **Per-row `idempotency_key`** on `create_evaluation_files` (`evaluation_service.py`, shape b): **forward-compat metadata** derived from stable identity (`evaluation_id` + group ordinal + `order_in_group`), built in lockstep with the registered batch and byte-stable across an HTTP-transport retry. **The backend currently ignores this field** (DTO uses Pydantic `extra="ignore"` → no validation error) and collapses retried/lost-response POSTs via **slot dedup `(file_meta_id, group, order)`** under `pg_advisory_xact_lock(evaluation_id)`; `file_meta_id` derives from `remote_object_name`. The key is sent for forward-compat (proven byte-stable by the alignment test); if the backend ever honors it, the formula should be aligned to the slot (include `remote_object_name`) so the two dedup dimensions can't disagree.
- **Stable manifest identity** (`upload_ledger.py` / `upload_manager.py`): substitutes a stable per-group ordinal into the manifest key/hash (and the process-files dedupe hash) for non-None (comparison) groups at all derivation sites, keeping cross-process resume identity stable. Single-stimulus `group=None` is left untouched, preserving backward compatibility with ledgers written by prior SDK versions.
- **Fail-closed guard**: if an already-registered row's local file metadata changed on resume, `_should_skip_upload` raises immediately rather than silently diverging from the backend record.

The SQLite schema change is additive (new `metadata_acked` column, default 0, backfilled to 1 for rows already in `metadata_registered`/`verified`), so existing ledgers migrate forward and remain readable by older SDKs.

**Backend contract (BE PR #5628):** the backend ignores `idempotency_key` (DTO `extra="ignore"`, no 422) and de-duplicates on the slot `(file_meta_id, group, order)` under an advisory lock. Duplicate coverage today: SDK exactly-once removes re-registration of already-registered rows in both configs (the no-ledger early-return and the ledger `metadata_acked` guard); the HTTP-transport retry reuses one request body so its slot is byte-identical and the backend collapses it; and a cross-process resume re-POST is gated behind a verify failure (an acked row is skipped; a `metadata_registering` row is verified first and only re-registered if verify fails, i.e. the original POST never persisted), so it has no committed original to duplicate. Caveat: the wire `group_id` regenerates per run, so the backend slot is **not** stable across resume for comparison groups; the `idempotency_key` (derived from stable identity, unaffected by the regen) is sent forward-compat to close the narrow "original committed but verify falsely failed" edge once the backend honors it.

## Test Plan
- [x] `python -m pytest tests/` — full suite green (623 passed, 11 skipped, 64 subtests)
- [x] New/updated regression coverage: no-ledger verify-failure re-upload without re-registration (`test_no_ledger_verify_failure_does_not_reregister`, `test_retry_failed_uploads_reuploads_without_reregistering_metadata`), acked-row-never-reregistered, reverify-without-reregister, merge-gate raises on reordered acked resume (not on same-order), single-stimulus distinct ordinals, idempotency-key alignment (byte-stability), migration backfill (ensure-column and table-rebuild paths), single-stimulus `group=None` cross-version resume, process-files dedupe hash stable across comparison `group_id` regen
- [x] Opt-in dev-server E2E (`tests/integration/verify_failure_reupload_e2e.py`, gated on `PODONOS_E2E=1` + `PODONOS_API_KEY`): uploads real files, forces exactly one verify failure in process so the SDK takes its real retry path, and asserts the failed file is re-uploaded, re-verified, and registered exactly once (no duplicate). Covers single (NMOS) / double (CMOS) / triple (CSMOS) group shapes across both configs, with guards that abort inconclusively if the backend state is not clean for injection
- [x] `ruff check` clean on changed files
- [x] Backward compatibility: resuming a ledger from a prior SDK version (single-stimulus `group=None`) does not crash

> Note (follow-up, not blocking): cross-process resume identity is positional, so a resume that re-adds groups in a different order now fails loud (raises) rather than duplicating; persisting the ordinal as a ledger column would make resume order-independent. The session-json dedupe hash remains unstable across resume via `AudioGroup.created_at` (pre-existing; an idempotent overwrite, not a row-dup path).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
