### PR TITLE
Release v0.42.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+## 0.42.0
+
+- Register uploaded file metadata exactly once across retries and resumed uploads, preventing duplicate registration of the same file
+
 ## 0.41.0
 
 - Harden resumable upload recovery so interrupted large-file uploads resume reliably

--- a/podonos/__init__.py
+++ b/podonos/__init__.py
@@ -2,6 +2,6 @@ from .core.file import File
 from .entity.flash_eval import FlashEvalResult
 from .sdk import Podonos, Client
 
-__version__ = "0.41.0"
+__version__ = "0.42.0"
 
 init = Podonos.init

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "podonos"
-version = "0.41.0"
+version = "0.42.0"
 description = "Managed evaluation for audio & speech"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Release v0.42.0 to PyPI.

## Changelog
- Register uploaded file metadata exactly once across retries and resumed uploads, preventing duplicate registration of the same file

PyPI: https://pypi.org/project/podonos/0.42.0/