### PR TITLE
feat(enum): add Dutch (nl-nl) and Swedish (sv-se) to Language enum

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+## 0.43.0
+
+- Add Dutch (`nl-nl`) and Swedish (`sv-se`) to `Language` enum
+
 ## 0.42.0
 
 - Register uploaded file metadata exactly once across retries and resumed uploads, preventing duplicate registration of the same file

--- a/podonos/__init__.py
+++ b/podonos/__init__.py
@@ -2,6 +2,6 @@ from .core.file import File
 from .entity.flash_eval import FlashEvalResult
 from .sdk import Podonos, Client
 
-__version__ = "0.42.0"
+__version__ = "0.43.0"
 
 init = Podonos.init

--- a/podonos/common/enum.py
+++ b/podonos/common/enum.py
@@ -194,6 +194,8 @@ class Language(Enum):
     ITALIAN = "it-it"
     POLISH = "pl-pl"
     INDONESIAN = "id-id"
+    DUTCH = "nl-nl"
+    SWEDISH = "sv-se"
     HINDI = "hi-in"
     TAMIL = "ta-in"
     KANNADA = "kn-in"

--- a/podonos/core/config.py
+++ b/podonos/core/config.py
@@ -295,6 +295,8 @@ class EvalConfig:
             Language.ITALIAN.value,
             Language.POLISH.value,
             Language.INDONESIAN.value,
+            Language.DUTCH.value,
+            Language.SWEDISH.value,
             Language.HINDI.value,
             Language.TAMIL.value,
             Language.KANNADA.value,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "podonos"
-version = "0.42.0"
+version = "0.43.0"
 description = "Managed evaluation for audio & speech"
 readme = "README.md"
 license = "MIT"

--- a/tests/common/test_enum.py
+++ b/tests/common/test_enum.py
@@ -25,6 +25,8 @@ class TestLanguageEnum(unittest.TestCase):
         self.assertEqual(Language.JAPANESE.value, "ja-jp")
         self.assertEqual(Language.ITALIAN.value, "it-it")
         self.assertEqual(Language.POLISH.value, "pl-pl")
+        self.assertEqual(Language.DUTCH.value, "nl-nl")
+        self.assertEqual(Language.SWEDISH.value, "sv-se")
         self.assertEqual(Language.HINDI.value, "hi-in")
         self.assertEqual(Language.TAMIL.value, "ta-in")
         self.assertEqual(Language.KANNADA.value, "kn-in")


### PR DESCRIPTION
## What
Adds Dutch (`nl-nl`) and Swedish (`sv-se`) to the SDK, with a matching test assertion, a `History.md` entry, and a version bump to `0.43.0`.

## Why
Both languages are already fully implemented on the platform (backend constants/migrations, frontend, i18n) but were missing from the public SDK, so SDK users could not pass `lan="nl-nl"` / `lan="sv-se"`.

## Changes
- `podonos/common/enum.py` — add `DUTCH = "nl-nl"`, `SWEDISH = "sv-se"` (next to Indonesian, matching backend ordering)
- `podonos/core/config.py` — add both to the `_validate_eval_language` supported-language allow-list. **This is the runtime gate** — the enum alone is not enough; without this `create_evaluator(lan="nl-nl")` raises `ValueError`.
- `tests/common/test_enum.py` — assert both new values (also auto-covered by the existing `test_validate_eval_language`, which iterates `Language.values()` through the validator)
- `History.md` — `0.43.0` changelog entry
- `pyproject.toml` + `podonos/__init__.py` — `0.42.0` → `0.43.0`

## Test
`python -m pytest tests/common/test_enum.py tests/core/test_config.py -v` → **43 passed**. `Language.from_value("nl-nl")` → `DUTCH`; `_validate_eval_language("sv-se")` → `Language.SWEDISH`.

## Note
There are two sources of truth for supported languages in the SDK (the `Language` enum and the `config.py` allow-list); both are curated in lockstep (e.g. `en-sg` is commented out in both). Consider unifying on `Language.values()` in a future change. These locales are currently gated to the internal "podonos" PostHog cohort in the web app; the SDK/API path does not consult that flag. Publishing `0.43.0` to PyPI is the follow-up after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)